### PR TITLE
fix: worker bootstrap and packaging for Paperclip installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,19 +3,22 @@
   "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.js",
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js"
+  },
   "scripts": {
+    "prebuild": "node ../../../scripts/ensure-plugin-build-deps.mjs",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "dev": "tsc --watch",
     "test": "vitest run"
   },
-  "peerDependencies": {
-    "@paperclipai/plugin-sdk": "^1.0.0",
-    "@paperclipai/shared": "^0.3.0"
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*",
+    "@paperclipai/shared": "workspace:*"
   },
   "devDependencies": {
-    "@paperclipai/plugin-sdk": "file:../paperclip/packages/plugins/sdk",
-    "@paperclipai/shared": "file:../paperclip/packages/shared",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,1 @@
 export { default as manifest } from "./manifest.js";
-export { default as plugin } from "./worker.js";

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -28,7 +28,7 @@ const manifest: PaperclipPluginManifestV1 = {
     "http.outbound",
     "secrets.read-ref",
     "webhooks.receive",
-    "instance.settings.register",
+    // "instance.settings.register",  // no UI in this repo
     "activity.log.write",
     "metrics.write",
     "agent.tools.register",
@@ -150,16 +150,17 @@ const manifest: PaperclipPluginManifestV1 = {
         "Receives Discord slash command and button interaction payloads.",
     },
   ],
-  ui: {
-    slots: [
-      {
-        type: "settingsPage",
-        id: SLOT_IDS.settingsPage,
-        displayName: "Discord Settings",
-        exportName: EXPORT_NAMES.settingsPage,
-      },
-    ],
-  },
+  // UI disabled — no settings page source in this repo
+  // ui: {
+  //   slots: [
+  //     {
+  //       type: "settingsPage",
+  //       id: SLOT_IDS.settingsPage,
+  //       displayName: "Discord Settings",
+  //       exportName: EXPORT_NAMES.settingsPage,
+  //     },
+  //   ],
+  // },
 };
 
 export default manifest;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,5 +1,6 @@
 import {
   definePlugin,
+  runWorker,
   type PluginContext,
   type PluginEvent,
   type PluginWebhookInput,
@@ -48,9 +49,10 @@ async function resolveChannel(
   return (override as string) ?? fallback ?? null;
 }
 
-export default definePlugin({
+const plugin = definePlugin({
   async setup(ctx) {
     const rawConfig = await ctx.config.get();
+    ctx.logger.info(`Discord plugin config: ${JSON.stringify(rawConfig)}`);
     const config = rawConfig as unknown as DiscordConfig;
 
     if (!config.discordBotTokenRef) {
@@ -275,3 +277,5 @@ export default definePlugin({
     return { status: "ok" };
   },
 });
+
+runWorker(plugin, import.meta.url);


### PR DESCRIPTION
## Summary

The plugin fails to install and run in Paperclip due to several packaging and bootstrap issues. This PR fixes all of them so the plugin installs, starts, and processes events correctly.

## Issues Fixed

### 1. Missing runWorker() call
The worker module uses export default definePlugin() but never calls runWorker(). Without this, the worker process exits immediately with code 0 — Paperclip reports the worker as crashed.

Fix: Change to const plugin = definePlugin(...) and add runWorker(plugin, import.meta.url).

### 2. SDK as peerDependency
The SDK was listed as peerDependency with file: devDependency override. The worker process needs the SDK at runtime. In a Paperclip monorepo, file: paths do not resolve.

Fix: Move to dependencies with workspace:*.

### 3. Missing paperclipPlugin field in package.json
Paperclip plugin loader uses this field to locate manifest and worker entrypoints.

Fix: Add paperclipPlugin field pointing to compiled outputs.

### 4. UI slots declared without source
Manifest declares ui.slots with a settings page and requires instance.settings.register capability, but no UI component source exists. Installation fails with entrypoints.ui is required when ui.slots are declared.

Fix: Comment out ui.slots and instance.settings.register until UI source is added.

### 5. Re-export of plugin from index.ts
index.ts re-exports the plugin definition, but the worker is loaded separately by Paperclip worker manager. The re-export causes double loading.

Fix: Only export the manifest from index.ts.

## How it was tested

1. Built with pnpm build — no errors
2. Installed in Paperclip — plugin status: ready
3. Verified worker stays alive (no crash/restart loop)
4. Verified event subscriptions registered (6 event types)
5. Created test issues — Discord notifications posted successfully with rich embeds

Note: This plugin also requires a core SDK fix (paperclipai/paperclip#988) for event subscriptions to work. Without that fix, ctx.events.on() handlers register locally but events are never forwarded from the host.