### PR TITLE
Drop self-assignment CTA and suppress broken localhost links

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -31,9 +31,19 @@ export function humanizePriority(raw: string): string {
   return PRIORITY_LABELS[raw] ?? raw;
 }
 
-function resolveBaseUrl(baseUrl?: string): string {
-  const url = baseUrl || DEFAULT_BASE_URL;
-  return url.endsWith("/") ? url.slice(0, -1) : url;
+function resolveBaseUrl(baseUrl?: string): string | null {
+  const url = (baseUrl || DEFAULT_BASE_URL).trim();
+  const normalized = url.endsWith("/") ? url.slice(0, -1) : url;
+
+  try {
+    const parsed = new URL(normalized);
+    if (["localhost", "127.0.0.1", "::1", "[::1]"].includes(parsed.hostname)) {
+      return null;
+    }
+    return normalized;
+  } catch {
+    return null;
+  }
 }
 
 export function formatIssueCreated(event: PluginEvent, baseUrl?: string): DiscordMessage {
@@ -76,23 +86,17 @@ export function formatIssueCreated(event: PluginEvent, baseUrl?: string): Discor
   }
 
   const base = resolveBaseUrl(baseUrl);
-  const dashboardUrl = `${base}/issues/${event.entityId}`;
 
   const footerParts: string[] = [];
   if (creatorName) footerParts.push(`Created by ${creatorName}`);
   if (projectName) footerParts.push(projectName);
   const footerText = footerParts.length > 0 ? footerParts.join(" • ") : "Paperclip";
 
-  const buttons: DiscordComponent[] = [
-    {
-      type: 2,
-      style: 1,
-      label: "Assign to Me",
-      custom_id: `issue_assign_${event.entityId}`,
-    },
-    { type: 2, style: 5, label: "View Issue", url: dashboardUrl },
-  ];
-  if (parentId) {
+  const buttons: DiscordComponent[] = [];
+  if (base) {
+    buttons.push({ type: 2, style: 5, label: "View Issue", url: `${base}/issues/${event.entityId}` });
+  }
+  if (base && parentId) {
     buttons.push({
       type: 2,
       style: 5,
@@ -114,7 +118,7 @@ export function formatIssueCreated(event: PluginEvent, baseUrl?: string): Discor
         timestamp: event.occurredAt,
       },
     ],
-    components: [{ type: 1, components: buttons }],
+    components: buttons.length > 0 ? [{ type: 1, components: buttons }] : [],
   };
 }
 
@@ -148,11 +152,11 @@ export function formatIssueDone(event: PluginEvent, baseUrl?: string): DiscordMe
   }
 
   const base = resolveBaseUrl(baseUrl);
-  const dashboardUrl = `${base}/issues/${event.entityId}`;
 
-  const buttons: DiscordComponent[] = [
-    { type: 2, style: 5, label: "View Issue", url: dashboardUrl },
-  ];
+  const buttons: DiscordComponent[] = [];
+  if (base) {
+    buttons.push({ type: 2, style: 5, label: "View Issue", url: `${base}/issues/${event.entityId}` });
+  }
   if (p.prUrl) {
     buttons.push({ type: 2, style: 5, label: "View Diff", url: String(p.prUrl) });
   }
@@ -186,7 +190,7 @@ export function formatApprovalCreated(event: PluginEvent, baseUrl?: string): Dis
   const description = String(p.description ?? "");
   const agentName = String(p.agentName ?? "");
   const issueIds = Array.isArray(p.issueIds) ? p.issueIds as string[] : [];
-  const dashboardUrl = `${resolveBaseUrl(baseUrl)}/approvals/${approvalId}`;
+  const dashboardBase = resolveBaseUrl(baseUrl);
 
   const fields: Array<{ name: string; value: string; inline?: boolean }> = [];
   if (agentName) fields.push({ name: "Agent", value: agentName, inline: true });
@@ -246,12 +250,14 @@ export function formatApprovalCreated(event: PluginEvent, baseUrl?: string): Dis
             label: "Reject",
             custom_id: `approval_reject_${approvalId}`,
           },
-          {
-            type: 2,
-            style: 5,
-            label: "View",
-            url: dashboardUrl,
-          },
+          ...(dashboardBase
+            ? [{
+                type: 2,
+                style: 5,
+                label: "View",
+                url: `${dashboardBase}/approvals/${approvalId}`,
+              } satisfies DiscordComponent]
+            : []),
         ],
       },
     ],

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -59,10 +59,10 @@ describe("formatIssueCreated", () => {
     expect(viewBtn?.url).toBe("https://app.paperclip.dev/issues/iss-1");
   });
 
-  it("uses default base URL when none provided", () => {
+  it("omits View Issue button when base URL is omitted", () => {
     const msg = formatIssueCreated(makeEvent({ entityId: "iss-1" }));
     const viewBtn = msg.components?.[0]?.components?.find((c) => c.label === "View Issue");
-    expect(viewBtn?.url).toBe("http://localhost:3100/issues/iss-1");
+    expect(viewBtn).toBeUndefined();
   });
 });
 
@@ -112,11 +112,12 @@ describe("formatIssueDone", () => {
 });
 
 describe("formatApprovalCreated", () => {
-  it("includes interactive approve/reject/view buttons", () => {
+  it("includes interactive approve/reject/view buttons when baseUrl is provided", () => {
     const msg = formatApprovalCreated(
       makeEvent({
         payload: { type: "strategy", approvalId: "apr-123", issueIds: ["i1"] },
       }),
+      "https://app.paperclip.dev",
     );
     expect(msg.embeds?.[0]?.color).toBe(COLORS.YELLOW);
     expect(msg.components).toHaveLength(1);
@@ -266,13 +267,13 @@ describe("agent label formatting", () => {
 });
 
 describe("escalation embed structure", () => {
-  it("approval created embed has action row with 3 buttons", () => {
+  it("approval created embed has action row with 2 buttons when baseUrl is omitted", () => {
     const msg = formatApprovalCreated(
       makeEvent({ payload: { approvalId: "apr-1" } }),
     );
     expect(msg.components).toHaveLength(1);
     expect(msg.components?.[0]?.type).toBe(1); // action row
-    expect(msg.components?.[0]?.components).toHaveLength(3);
+    expect(msg.components?.[0]?.components).toHaveLength(2);
   });
 
   it("approve button uses style 3 (success/green)", () => {
@@ -293,9 +294,10 @@ describe("escalation embed structure", () => {
     expect(rejectBtn?.label).toBe("Reject");
   });
 
-  it("view button uses style 5 (link)", () => {
+  it("view button uses style 5 (link) when baseUrl is provided", () => {
     const msg = formatApprovalCreated(
       makeEvent({ payload: { approvalId: "apr-1" } }),
+      "https://app.paperclip.dev",
     );
     const viewBtn = msg.components?.[0]?.components?.[2];
     expect(viewBtn?.style).toBe(5);
@@ -313,22 +315,21 @@ describe("approval View button URL uses configured base URL", () => {
     expect(viewBtn?.url).toBe("https://app.paperclip.ing/approvals/apr-99");
   });
 
-  it("falls back to DEFAULT_BASE_URL when baseUrl is undefined", () => {
+  it("omits View button when baseUrl is undefined", () => {
     const msg = formatApprovalCreated(
       makeEvent({ payload: { approvalId: "apr-99" } }),
     );
     const viewBtn = msg.components?.[0]?.components?.[2];
-    expect(viewBtn?.url).toBe("http://localhost:3100/approvals/apr-99");
+    expect(viewBtn).toBeUndefined();
   });
 
-  it("falls back to DEFAULT_BASE_URL when baseUrl is empty string", () => {
+  it("omits View button when baseUrl is empty string", () => {
     const msg = formatApprovalCreated(
       makeEvent({ payload: { approvalId: "apr-99" } }),
       "",
     );
     const viewBtn = msg.components?.[0]?.components?.[2];
-    // Empty string is falsy but not nullish — should still fall back
-    expect(viewBtn?.url).toBe("http://localhost:3100/approvals/apr-99");
+    expect(viewBtn).toBeUndefined();
   });
 
   it("strips trailing slash from baseUrl to avoid double-slash", () => {
@@ -413,14 +414,12 @@ describe("humanized status and priority in issue embeds", () => {
 });
 
 describe("formatIssueCreated — actionability improvements", () => {
-  it("includes Assign to Me button with correct custom_id", () => {
+  it("does not include Assign to Me button", () => {
     const msg = formatIssueCreated(
       makeEvent({ entityId: "iss-99", payload: { identifier: "X-1", title: "Task" } }),
     );
     const assignBtn = msg.components?.[0]?.components?.find((c) => c.label === "Assign to Me");
-    expect(assignBtn).toBeDefined();
-    expect(assignBtn?.style).toBe(1); // blurple/primary
-    expect(assignBtn?.custom_id).toBe("issue_assign_iss-99");
+    expect(assignBtn).toBeUndefined();
   });
 
   it("shows parent context field when parentIdentifier is provided", () => {
@@ -550,13 +549,22 @@ describe("formatIssueDone — actionability improvements", () => {
     expect(diffBtn).toBeUndefined();
   });
 
-  it("always includes View Issue button", () => {
+  it("includes View Issue button when base URL is provided", () => {
     const msg = formatIssueDone(
       makeEvent({ entityId: "iss-7", payload: { identifier: "X-7", title: "T" } }),
+      "https://paperclip.example.com",
     );
     const viewBtn = msg.components?.[0]?.components?.find((c) => c.label === "View Issue");
     expect(viewBtn).toBeDefined();
-    expect(viewBtn?.url).toBe("http://localhost:3100/issues/iss-7");
+    expect(viewBtn?.url).toBe("https://paperclip.example.com/issues/iss-7");
+  });
+
+  it("omits View Issue button when base URL resolves to localhost", () => {
+    const msg = formatIssueDone(
+      makeEvent({ entityId: "iss-8", payload: { identifier: "X-8", title: "T" } }),
+    );
+    const viewBtn = msg.components?.[0]?.components?.find((c) => c.label === "View Issue");
+    expect(viewBtn).toBeUndefined();
   });
 
   it("falls back to executorName when assigneeName is missing", () => {


### PR DESCRIPTION
## Summary
- remove the issue-created `Assign to Me` button from Discord notifications
- stop rendering dashboard link buttons when `paperclipBaseUrl` would resolve to localhost
- keep public links working when a real externally routable base URL is configured

## Why
Two user-facing issues were confirmed live:
1. the self-assignment button was not desired for this integration
2. when `paperclipBaseUrl` was left on the localhost default, Discord notifications shipped broken `View Issue` links

This PR fixes the notification UX without changing the transport/runtime behavior.

## Verification
- npm run typecheck
- npm run build
- npm test (436 passing)