### PR TITLE
fix: embed companyId in escalation button custom_ids for multi-company support

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1354,14 +1354,25 @@ async function handleEscalationButton(
   actor: string,
   _baseUrl: string,
 ): Promise<unknown> {
+  // Button custom_id format: esc_{action}_{companyId}_{escalationId}
+  // Legacy format (pre-fix): esc_{action}_{escalationId}
+  // CompanyId is a UUID (contains hyphens), escalationId starts with "esc_".
+  // We split on "_" to get the action, then look for a UUID-shaped segment.
   const parts = customId.split("_");
   const action = parts[1];
-  const escalationId = parts.slice(2).join("_");
+  const remaining = parts.slice(2).join("_");
 
-  ctx.logger.info("Escalation button clicked", { escalationId, action, actor });
+  // Try to extract embedded companyId: UUID pattern before the escalation ID
+  const uuidEscMatch = remaining.match(
+    /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})_(esc_.+)$/i,
+  );
+  const embeddedCompanyId = uuidEscMatch ? uuidEscMatch[1] : null;
+  const escalationId = uuidEscMatch ? uuidEscMatch[2] : remaining;
 
-  const resolvedCompanyId = await resolveCompanyId(ctx);
-  const record = await getEscalation(ctx, escalationId, resolvedCompanyId) as {
+  ctx.logger.info("Escalation button clicked", { escalationId, action, actor, embeddedCompanyId });
+
+  const companyIdForLookup = embeddedCompanyId ?? await resolveCompanyId(ctx);
+  const record = await getEscalation(ctx, escalationId, companyIdForLookup) as {
     escalationId: string; companyId: string; agentName: string;
     reason: string; suggestedReply?: string; status: string;
   } | null;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -590,20 +590,21 @@ const plugin = definePlugin({
       ];
 
       const buttons: DiscordComponent[] = [];
+      const cid = payload.companyId || "default";
 
       if (payload.suggestedReply) {
         buttons.push({
           type: 2,
           style: 3,
           label: "Use Suggested Reply",
-          custom_id: `esc_suggest_${payload.escalationId}`,
+          custom_id: `esc_suggest_${cid}_${payload.escalationId}`,
         });
       }
 
       buttons.push(
-        { type: 2, style: 1, label: "Reply to Customer", custom_id: `esc_reply_${payload.escalationId}` },
-        { type: 2, style: 2, label: "Override Agent", custom_id: `esc_override_${payload.escalationId}` },
-        { type: 2, style: 4, label: "Dismiss", custom_id: `esc_dismiss_${payload.escalationId}` },
+        { type: 2, style: 1, label: "Reply to Customer", custom_id: `esc_reply_${cid}_${payload.escalationId}` },
+        { type: 2, style: 2, label: "Override Agent", custom_id: `esc_override_${cid}_${payload.escalationId}` },
+        { type: 2, style: 4, label: "Dismiss", custom_id: `esc_dismiss_${cid}_${payload.escalationId}` },
       );
 
       const components: DiscordComponent[] = [{ type: 1, components: buttons }];


### PR DESCRIPTION
Fixes #29

## Summary

- Embeds `companyId` in escalation button `custom_id` fields: `esc_{action}_{companyId}_{escalationId}`
- Click handler extracts UUID-shaped companyId from custom_id for direct state lookup
- Falls back to `resolveCompanyId()` for old-format buttons (`esc_{action}_{escalationId}`)
- No changes to `company-resolver.ts` — the cache issue only matters when companyId is not embedded

## Test plan

- [ ] New escalation buttons include companyId in custom_id
- [ ] Clicking buttons on new-format escalations resolves correctly across multiple companies
- [ ] Old-format buttons (pre-upgrade) still work via resolveCompanyId fallback
- [ ] Single-company setups are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)