### PR TITLE
Fix Discord snowflake ID precision loss in channel routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,15 +12,16 @@
     "typecheck": "tsc --noEmit",
     "dev": "tsc --watch",
     "test": "vitest run",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "prepare": "npm run build"
   },
   "peerDependencies": {
     "@paperclipai/plugin-sdk": "*",
     "@paperclipai/shared": "*"
   },
   "devDependencies": {
-    "@paperclipai/plugin-sdk": "^2026.318.0",
-    "@paperclipai/shared": "^2026.318.0",
+    "@paperclipai/plugin-sdk": "^2026.403.0",
+    "@paperclipai/shared": "^2026.403.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },

--- a/src/discord-api.ts
+++ b/src/discord-api.ts
@@ -61,18 +61,23 @@ async function discordFetch(
   return ctx.http.fetch(url, init);
 }
 
+function normalizeDiscordPathId(id: string | number): string {
+  return String(id);
+}
+
 export async function postEmbed(
   ctx: PluginContext,
   token: string,
-  channelId: string,
+  channelId: string | number,
   message: DiscordMessage,
 ): Promise<boolean> {
+  const safeChannelId = normalizeDiscordPathId(channelId);
   try {
     await withRetry(async () => {
       const response = await discordFetch(
         ctx,
         token,
-        `/channels/${channelId}/messages`,
+        `/channels/${safeChannelId}/messages`,
         {
           method: "POST",
           body: {
@@ -91,7 +96,7 @@ export async function postEmbed(
         ctx.logger.warn("Discord API error", {
           status: response.status,
           body: text,
-          channelId,
+          channelId: safeChannelId,
         });
         throw err;
       }
@@ -111,16 +116,17 @@ export async function postEmbed(
 export async function postEmbedWithId(
   ctx: PluginContext,
   token: string,
-  channelId: string,
+  channelId: string | number,
   message: DiscordMessage,
 ): Promise<string | null> {
+  const safeChannelId = normalizeDiscordPathId(channelId);
   try {
     let messageId: string | null = null;
     await withRetry(async () => {
       const response = await discordFetch(
         ctx,
         token,
-        `/channels/${channelId}/messages`,
+        `/channels/${safeChannelId}/messages`,
         {
           method: "POST",
           body: {
@@ -139,7 +145,7 @@ export async function postEmbedWithId(
         ctx.logger.warn("Discord API error", {
           status: response.status,
           body: text,
-          channelId,
+          channelId: safeChannelId,
         });
         throw err;
       }
@@ -163,18 +169,19 @@ export async function registerSlashCommands(
   ctx: PluginContext,
   token: string,
   applicationId: string,
-  guildId: string,
+  guildId: string | number,
   commands: Array<{
     name: string;
     description: string;
     options?: unknown[];
   }>,
 ): Promise<boolean> {
+  const safeGuildId = normalizeDiscordPathId(guildId);
   try {
     const response = await discordFetch(
       ctx,
       token,
-      `/applications/${applicationId}/guilds/${guildId}/commands`,
+      `/applications/${applicationId}/guilds/${safeGuildId}/commands`,
       { method: "PUT", body: commands },
     );
     if (!response.ok) {
@@ -197,14 +204,15 @@ export async function registerSlashCommands(
 export async function getChannelMessages(
   ctx: PluginContext,
   token: string,
-  channelId: string,
+  channelId: string | number,
   limit: number = 100,
 ): Promise<DiscordChannelMessage[]> {
+  const safeChannelId = normalizeDiscordPathId(channelId);
   try {
     const response = await discordFetch(
       ctx,
       token,
-      `/channels/${channelId}/messages?limit=${limit}`,
+      `/channels/${safeChannelId}/messages?limit=${limit}`,
     );
     if (!response.ok) return [];
     return (await response.json()) as DiscordChannelMessage[];
@@ -216,7 +224,7 @@ export async function getChannelMessages(
 export async function getChannelMessagesAll(
   ctx: PluginContext,
   token: string,
-  channelId: string,
+  channelId: string | number,
   opts: {
     maxMessages?: number;
     maxAgeDays?: number;
@@ -224,6 +232,7 @@ export async function getChannelMessagesAll(
     onProgress?: (fetched: number) => void;
   } = {},
 ): Promise<DiscordChannelMessage[]> {
+  const safeChannelId = normalizeDiscordPathId(channelId);
   const maxMessages = opts.maxMessages ?? 5000;
   const maxAgeDays = opts.maxAgeDays ?? 90;
   const pageDelayMs = opts.pageDelayMs ?? 500;
@@ -234,8 +243,8 @@ export async function getChannelMessagesAll(
 
   while (allMessages.length < maxMessages) {
     const query = before
-      ? `/channels/${channelId}/messages?limit=100&before=${before}`
-      : `/channels/${channelId}/messages?limit=100`;
+      ? `/channels/${safeChannelId}/messages?limit=100&before=${before}`
+      : `/channels/${safeChannelId}/messages?limit=100`;
 
     try {
       const response = await discordFetch(ctx, token, query);
@@ -270,13 +279,14 @@ export async function getChannelMessagesAll(
 export async function getGuildRoles(
   ctx: PluginContext,
   token: string,
-  guildId: string,
+  guildId: string | number,
 ): Promise<DiscordGuildRole[]> {
+  const safeGuildId = normalizeDiscordPathId(guildId);
   try {
     const response = await discordFetch(
       ctx,
       token,
-      `/guilds/${guildId}/roles`,
+      `/guilds/${safeGuildId}/roles`,
     );
     if (!response.ok) return [];
     return (await response.json()) as DiscordGuildRole[];

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -108,17 +108,32 @@ interface EscalationCreatedPayload {
   suggestedReply?: string;
 }
 
+const SNOWFLAKE_ID_REGEX = /^\d{17,20}$/;
+
+function normalizeDiscordId(value: unknown): string | null {
+  if (value == null) return null;
+  const normalized = String(value).trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeDiscordIdList(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  return values
+    .map((value) => normalizeDiscordId(value))
+    .filter((value): value is string => value !== null);
+}
+
 async function resolveChannel(
   ctx: PluginContext,
   companyId: string,
-  fallback: string,
+  fallback: unknown,
 ): Promise<string | null> {
   const override = await ctx.state.get({
     scopeKind: "company",
     scopeId: companyId,
     stateKey: "discord-channel",
   });
-  return (override as string) ?? fallback ?? null;
+  return normalizeDiscordId(override) ?? normalizeDiscordId(fallback);
 }
 
 async function enrichIssueNotificationPayload(
@@ -248,6 +263,13 @@ const plugin = definePlugin({
     const token = await ctx.secrets.resolve(config.discordBotTokenRef);
     const baseUrl = config.paperclipBaseUrl || "http://localhost:3100";
     const retentionDays = config.intelligenceRetentionDays || 30;
+    const defaultGuildId = normalizeDiscordId(config.defaultGuildId);
+    const defaultChannelId = normalizeDiscordId(config.defaultChannelId) ?? "";
+    const approvalsChannelId = normalizeDiscordId(config.approvalsChannelId);
+    const errorsChannelId = normalizeDiscordId(config.errorsChannelId);
+    const bdPipelineChannelId = normalizeDiscordId(config.bdPipelineChannelId);
+    const escalationChannelId = normalizeDiscordId(config.escalationChannelId) ?? defaultChannelId;
+    const intelligenceChannelIds = normalizeDiscordIdList(config.intelligenceChannelIds);
 
     // Company ID is resolved lazily on first /clip command or job invocation,
     // NOT during setup — startup-time API calls can cause worker activation to fail.
@@ -257,7 +279,7 @@ const plugin = definePlugin({
       baseUrl,
       companyId,
       token,
-      defaultChannelId: config.defaultChannelId,
+      defaultChannelId,
       pluginCtx: ctx,
     };
 
@@ -266,14 +288,14 @@ const plugin = definePlugin({
     _cmdCtx = cmdCtx;
 
     // --- Register slash commands with Discord ---
-    if (config.defaultGuildId) {
+    if (defaultGuildId) {
       const appId = await getApplicationId(ctx, token);
       if (appId) {
         const registered = await registerSlashCommands(
           ctx,
           token,
           appId,
-          config.defaultGuildId,
+          defaultGuildId,
           SLASH_COMMANDS,
         );
         if (registered) {
@@ -436,7 +458,7 @@ const plugin = definePlugin({
         stateKey: "channel-project-map",
       })) as Record<string, string> | null;
 
-      return channelMap?.[projectName] ?? null;
+      return normalizeDiscordId(channelMap?.[projectName]) ?? null;
     };
 
     const notify = async (
@@ -480,9 +502,10 @@ const plugin = definePlugin({
     };
 
     if (config.notifyOnIssueCreated) {
-      ctx.events.on("issue.created", (event: PluginEvent) =>
-        notify(event, formatIssueCreated),
-      );
+      ctx.events.on("issue.created", async (event: PluginEvent) => {
+        const payload = await enrichIssueNotificationPayload(ctx, event);
+        await notify({ ...event, payload }, formatIssueCreated);
+      });
     }
 
     if (config.notifyOnIssueDone) {
@@ -513,21 +536,21 @@ const plugin = definePlugin({
 
     if (config.notifyOnApprovalCreated) {
       ctx.events.on("approval.created", (event: PluginEvent) =>
-        notify(event, formatApprovalCreated, config.approvalsChannelId),
+        notify(event, formatApprovalCreated, approvalsChannelId ?? undefined),
       );
     }
 
     if (config.notifyOnAgentError) {
       ctx.events.on("agent.run.failed", (event: PluginEvent) =>
-        notify(event, formatSessionFailure, config.errorsChannelId),
+        notify(event, formatSessionFailure, errorsChannelId ?? undefined),
       );
     }
 
     ctx.events.on("agent.run.started", (event: PluginEvent) =>
-      notify(event, formatAgentRunStarted, config.bdPipelineChannelId),
+      notify(event, formatAgentRunStarted, bdPipelineChannelId ?? undefined),
     );
     ctx.events.on("agent.run.finished", (event: PluginEvent) =>
-      notify(event, formatAgentRunFinished, config.bdPipelineChannelId),
+      notify(event, formatAgentRunFinished, bdPipelineChannelId ?? undefined),
     );
 
     // ===================================================================
@@ -535,7 +558,6 @@ const plugin = definePlugin({
     // ===================================================================
 
     const adapter = new DiscordAdapter(ctx, token);
-    const escalationChannelId = config.escalationChannelId || config.defaultChannelId;
     const escalationTimeoutMs = (config.escalationTimeoutMinutes || 30) * 60 * 1000;
 
     // Escalation state helpers are imported from ./escalation-state.js
@@ -916,7 +938,7 @@ const plugin = definePlugin({
         const channelId = await resolveChannel(
           ctx,
           jobCompanyId,
-          config.errorsChannelId || config.defaultChannelId,
+          errorsChannelId ?? defaultChannelId,
         );
         if (!channelId) continue;
 
@@ -1031,7 +1053,7 @@ const plugin = definePlugin({
         return;
       }
       const cid = await resolveCompanyId(ctx);
-      await checkWatches(ctx, token, cid, config.defaultChannelId);
+      await checkWatches(ctx, token, cid, defaultChannelId);
     });
 
     // ===================================================================
@@ -1071,7 +1093,7 @@ const plugin = definePlugin({
 
       const companies = await ctx.companies.list();
       for (const company of companies) {
-        const channelId = await resolveChannel(ctx, company.id, config.defaultChannelId);
+        const channelId = await resolveChannel(ctx, company.id, defaultChannelId);
         if (!channelId) continue;
 
         try {
@@ -1202,12 +1224,18 @@ const plugin = definePlugin({
         scopeId: cid,
         stateKey: "discord-channel",
       });
-      return { channelId: saved ?? config.defaultChannelId };
+      return { channelId: normalizeDiscordId(saved) ?? defaultChannelId };
     });
 
     ctx.actions.register("set-channel", async (params) => {
       const cid = String(params.companyId);
-      const channelId = String(params.channelId);
+      if (typeof params.channelId !== "string") {
+        return { ok: false, error: "Invalid channel ID - must be a snowflake string" };
+      }
+      const channelId = params.channelId.trim();
+      if (!SNOWFLAKE_ID_REGEX.test(channelId)) {
+        return { ok: false, error: "Invalid channel ID - must be a snowflake string" };
+      }
       await ctx.state.set(
         { scopeKind: "company", scopeId: cid, stateKey: "discord-channel" },
         channelId,
@@ -1259,7 +1287,7 @@ const plugin = definePlugin({
     // --- Intelligence: scheduled scan ---
 
     ctx.jobs.register("discord-intelligence-scan", async () => {
-      if (!config.enableIntelligence || !config.intelligenceChannelIds?.length) {
+      if (!config.enableIntelligence || intelligenceChannelIds.length === 0 || !defaultGuildId) {
         ctx.logger.debug("discord-intelligence-scan: intelligence disabled or no channels configured, skipping");
         return;
       }
@@ -1267,21 +1295,21 @@ const plugin = definePlugin({
       await runIntelligenceScan(
         ctx,
         token,
-        config.defaultGuildId,
-        config.intelligenceChannelIds,
+        defaultGuildId,
+        intelligenceChannelIds,
         cid,
         retentionDays,
       );
     });
-    if (config.enableIntelligence && config.intelligenceChannelIds.length > 0) {
+    if (config.enableIntelligence && intelligenceChannelIds.length > 0) {
       ctx.logger.info("Intelligence scan job registered", {
-        channels: config.intelligenceChannelIds.length,
+        channels: intelligenceChannelIds.length,
       });
     }
 
     // --- Backfill ---
 
-    if (config.enableIntelligence && config.intelligenceChannelIds.length > 0) {
+    if (config.enableIntelligence && intelligenceChannelIds.length > 0 && defaultGuildId) {
       // Backfill also deferred to avoid startup-time company resolution.
       // It runs as an async task after setup completes.
       const tryBackfill = async () => {
@@ -1297,8 +1325,8 @@ const plugin = definePlugin({
           await runBackfill(
             ctx,
             token,
-            config.defaultGuildId,
-            config.intelligenceChannelIds,
+            defaultGuildId,
+            intelligenceChannelIds,
             cid,
             config.backfillDays ?? 90,
           );
@@ -1316,8 +1344,8 @@ const plugin = definePlugin({
         const signals = await runBackfill(
           ctx,
           token,
-          config.defaultGuildId,
-          config.intelligenceChannelIds,
+          defaultGuildId,
+          intelligenceChannelIds,
           cid,
           config.backfillDays ?? 90,
         );

--- a/tests/event-dedup.test.ts
+++ b/tests/event-dedup.test.ts
@@ -157,6 +157,16 @@ async function emitEvent(
   }
 }
 
+function findDiscordPostBody(mockDiscordFetch: ReturnType<typeof vi.fn>) {
+  const postCall = mockDiscordFetch.mock.calls.find(
+    (call: any[]) => typeof call[0] === "string" && call[0].includes("/channels/") && typeof call[1]?.body === "string",
+  );
+  if (!postCall) {
+    throw new Error("Expected a Discord channel POST with a JSON body");
+  }
+  return JSON.parse(postCall[1].body);
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -263,7 +273,7 @@ describe("event deduplication", () => {
 
     await emitEvent(eventHandlers, "issue.updated", event);
 
-    const requestBody = JSON.parse(mockDiscordFetch.mock.calls[0][1].body);
+    const requestBody = findDiscordPostBody(mockDiscordFetch);
     const embed = requestBody.embeds[0];
     const completedByField = embed.fields.find((f: { name: string }) => f.name === "Completed by");
     const summaryField = embed.fields.find((f: { name: string }) => f.name === "Summary");
@@ -305,7 +315,7 @@ describe("event deduplication", () => {
 
     await emitEvent(eventHandlers, "issue.updated", event);
 
-    const requestBody = JSON.parse(mockDiscordFetch.mock.calls[0][1].body);
+    const requestBody = findDiscordPostBody(mockDiscordFetch);
     const embed = requestBody.embeds[0];
     const completedByField = embed.fields.find((f: { name: string }) => f.name === "Completed by");
     const summaryField = embed.fields.find((f: { name: string }) => f.name === "Summary");
@@ -339,7 +349,7 @@ describe("event deduplication", () => {
 
     await emitEvent(eventHandlers, "issue.updated", event);
 
-    const requestBody = JSON.parse(mockDiscordFetch.mock.calls[0][1].body);
+    const requestBody = findDiscordPostBody(mockDiscordFetch);
     const embed = requestBody.embeds[0];
     const completedByField = embed.fields.find((f: { name: string }) => f.name === "Completed by");
     expect(completedByField.value).toBe("Board user");

--- a/tests/topic-routing.test.ts
+++ b/tests/topic-routing.test.ts
@@ -266,7 +266,7 @@ describe("topic routing", () => {
   it("enriches issue.created before topic routing so issue project names can map to a topic channel", async () => {
     const { ctx, eventHandlers, mockDiscordFetch } = buildPluginContext(
       { topicRouting: true, notifyOnIssueCreated: true },
-      { "channel-project-map": { "my-project": "1492469315486748802" } },
+      { "channel-project-map": { "my-project": "1234567890123456789" } },
     );
     ctx.issues.get = vi.fn().mockResolvedValue({
       id: "entity-1",
@@ -289,7 +289,7 @@ describe("topic routing", () => {
       (call: any[]) => typeof call[0] === "string" && call[0].includes("/channels/"),
     );
     expect(postCall).toBeDefined();
-    expect(postCall![0]).toContain("1492469315486748802");
+    expect(postCall![0]).toContain("1234567890123456789");
   });
 
   it("rejects non-string set-channel inputs so truncated numeric snowflakes cannot be stored", async () => {
@@ -301,7 +301,7 @@ describe("topic routing", () => {
 
     const numericResult = await setChannel!({
       companyId: "company-1",
-      channelId: 1492469315486748802,
+      channelId: 1234567890123456789,
     });
     expect(numericResult).toEqual({
       ok: false,
@@ -311,12 +311,12 @@ describe("topic routing", () => {
 
     const validResult = await setChannel!({
       companyId: "company-1",
-      channelId: "1492469315486748802",
+      channelId: "1234567890123456789",
     });
     expect(validResult).toEqual({ ok: true });
     expect(ctx.state.set).toHaveBeenCalledWith(
       expect.objectContaining({ scopeKind: "company", scopeId: "company-1", stateKey: "discord-channel" }),
-      "1492469315486748802",
+      "1234567890123456789",
     );
   });
 });

--- a/tests/topic-routing.test.ts
+++ b/tests/topic-routing.test.ts
@@ -30,6 +30,7 @@ function getSetup(): (ctx: any) => Promise<void> {
 
 function buildPluginContext(configOverrides: Record<string, unknown> = {}, stateOverrides: Record<string, unknown> = {}) {
   const eventHandlers = new Map<string, Array<(event: any) => Promise<void>>>();
+  const actionHandlers = new Map<string, (params: any) => Promise<any>>();
   let discordMessageCount = 0;
 
   const defaultConfig: Record<string, unknown> = {
@@ -94,7 +95,11 @@ function buildPluginContext(configOverrides: Record<string, unknown> = {}, state
     jobs: { register: vi.fn() },
     tools: { register: vi.fn() },
     data: { register: vi.fn() },
-    actions: { register: vi.fn() },
+    actions: {
+      register: vi.fn().mockImplementation((name: string, fn: (params: any) => Promise<any>) => {
+        actionHandlers.set(name, fn);
+      }),
+    },
     events: {
       subscribe: vi.fn(),
       emit: vi.fn(),
@@ -107,11 +112,15 @@ function buildPluginContext(configOverrides: Record<string, unknown> = {}, state
     },
     companies: { list: vi.fn().mockResolvedValue([]) },
     agents: { list: vi.fn().mockResolvedValue([]), invoke: vi.fn() },
-    issues: { list: vi.fn().mockResolvedValue([]) },
+    issues: {
+      list: vi.fn().mockResolvedValue([]),
+      get: vi.fn().mockResolvedValue(null),
+      listComments: vi.fn().mockResolvedValue([]),
+    },
     http: { fetch: mockDiscordFetch },
   } as any;
 
-  return { ctx, eventHandlers, mockDiscordFetch };
+  return { ctx, eventHandlers, actionHandlers, mockDiscordFetch };
 }
 
 function makeEvent(eventType: string, eventId: string, payload: Record<string, unknown> = {}): any {
@@ -252,5 +261,62 @@ describe("topic routing", () => {
     );
     expect(postCall).toBeDefined();
     expect(postCall![0]).toContain("ch-default");
+  });
+
+  it("enriches issue.created before topic routing so issue project names can map to a topic channel", async () => {
+    const { ctx, eventHandlers, mockDiscordFetch } = buildPluginContext(
+      { topicRouting: true, notifyOnIssueCreated: true },
+      { "channel-project-map": { "my-project": "1492469315486748802" } },
+    );
+    ctx.issues.get = vi.fn().mockResolvedValue({
+      id: "entity-1",
+      identifier: "TST-6",
+      title: "Created issue",
+      status: "todo",
+      project: { name: "my-project" },
+    });
+
+    await getSetup()(ctx);
+
+    const event = makeEvent("issue.created", "evt-topic-6", {
+      title: "Created issue",
+      identifier: "TST-6",
+    });
+
+    await emitEvent(eventHandlers, "issue.created", event);
+
+    const postCall = mockDiscordFetch.mock.calls.find(
+      (call: any[]) => typeof call[0] === "string" && call[0].includes("/channels/"),
+    );
+    expect(postCall).toBeDefined();
+    expect(postCall![0]).toContain("1492469315486748802");
+  });
+
+  it("rejects non-string set-channel inputs so truncated numeric snowflakes cannot be stored", async () => {
+    const { ctx, actionHandlers } = buildPluginContext();
+    await getSetup()(ctx);
+
+    const setChannel = actionHandlers.get("set-channel");
+    expect(setChannel).toBeDefined();
+
+    const numericResult = await setChannel!({
+      companyId: "company-1",
+      channelId: 1492469315486748802,
+    });
+    expect(numericResult).toEqual({
+      ok: false,
+      error: "Invalid channel ID - must be a snowflake string",
+    });
+    expect(ctx.state.set).not.toHaveBeenCalled();
+
+    const validResult = await setChannel!({
+      companyId: "company-1",
+      channelId: "1492469315486748802",
+    });
+    expect(validResult).toEqual({ ok: true });
+    expect(ctx.state.set).toHaveBeenCalledWith(
+      expect.objectContaining({ scopeKind: "company", scopeId: "company-1", stateKey: "discord-channel" }),
+      "1492469315486748802",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Discord snowflake IDs exceed `Number.MAX_SAFE_INTEGER` and get silently truncated when passing through JSON serialization, causing 404 "Unknown Channel" errors
- Added `normalizeDiscordId()` and `normalizeDiscordPathId()` helpers that ensure all channel/guild IDs are handled as strings throughout the pipeline
- Fixed `issue.created` handler to enrich payload before `notify()` so `projectName` is available for topic routing
- Added snowflake validation in `set-channel` action
- All existing tests pass, new regression tests added for snowflake handling

## Changes

- `src/worker.ts` — `normalizeDiscordId()` helper, string guards on all config channel ID access, `resolveChannel` returns `string | null`, `issue.created` enrichment
- `src/discord-api.ts` — `normalizeDiscordPathId()` on all channel/guild IDs in API URLs
- `tests/topic-routing.test.ts` — regression tests for snowflake precision
- `tests/event-dedup.test.ts` — updated for enrichment change
- `package.json` — `prepare` script for GitHub install support

## Test plan

- [x] `npm test` — 443/443 tests pass
- [x] `npm run build` — clean compile
- [ ] Live verification: `defaultChannelId` routing with snowflake IDs works
- [ ] Live verification: `issue.created` topic routing populates `projectName`

🤖 Generated with [Claude Code](https://claude.com/claude-code)