### PR TITLE
fix: look up assignee agent name when executionAgentNameKey is null

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -171,6 +171,14 @@ async function enrichIssueNotificationPayload(
       if (payload.assigneeAgentId == null) payload.assigneeAgentId = issue.assigneeAgentId;
       if (payload.assigneeUserId == null) payload.assigneeUserId = issue.assigneeUserId;
       if (payload.agentName == null) payload.agentName = issue.executionAgentNameKey;
+      // executionAgentNameKey is not always populated — fall back to looking up the
+      // assignee agent's display name so "Completed by" shows "Scribe" not "Agent".
+      if (payload.agentName == null && (payload.assigneeAgentId || issue.assigneeAgentId)) {
+        const agentId = payload.assigneeAgentId ?? issue.assigneeAgentId;
+        const agents = await ctx.agents.list({ companyId });
+        const match = (agents as Array<{ id: string; name: string }>).find((a) => a.id === agentId);
+        if (match?.name) payload.agentName = match.name;
+      }
       if (payload.completedAt == null && issue.completedAt) payload.completedAt = String(issue.completedAt);
       if (payload.updatedAt == null && issue.updatedAt) payload.updatedAt = String(issue.updatedAt);
       if (payload.projectName == null && issue.project?.name) payload.projectName = issue.project.name;


### PR DESCRIPTION
## Problem

When an agent completes an issue, the Discord notification shows:

> **Completed by:** Agent

instead of the agent's actual display name (e.g. "Scribe", "Claira").

## Root cause

In `enrichIssueNotificationPayload`, `agentName` is populated from `issue.executionAgentNameKey`. This field is not reliably set by the Paperclip platform — in practice it's frequently `null`. When it's null, the fallback on line 200:

```ts
payload.completedBy = payload.agentName ?? "Agent";
```

produces the literal string `"Agent"`, which `formatIssueDone` then uses verbatim as the "Completed by" field value.

## Fix

After the existing `executionAgentNameKey` assignment, if `agentName` is still `null` but an `assigneeAgentId` is available, call `ctx.agents.list()` to look up the agent's display name and use it as `agentName`. The `"Agent"` fallback then only fires if the agent truly can't be found.

```ts
if (payload.agentName == null && (payload.assigneeAgentId || issue.assigneeAgentId)) {
  const agentId = payload.assigneeAgentId ?? issue.assigneeAgentId;
  const agents = await ctx.agents.list({ companyId });
  const match = (agents as Array<{ id: string; name: string }>).find((a) => a.id === agentId);
  if (match?.name) payload.agentName = match.name;
}
```

Verified against v0.7.0 in production — "Completed by" now shows the agent display name correctly.

## Notes

- No changes to the formatter or event schema — fix is entirely in the enrichment step
- `ctx.agents.list()` is already used elsewhere in `worker.ts` with the same cast pattern
- The `"Agent"` fallback is preserved as a last resort if the lookup fails