### PR TITLE
chore: bump version to 0.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paperclip-plugin-discord",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "type": "module",
   "main": "./dist/index.js",
   "paperclipPlugin": {


### PR DESCRIPTION
Publishes #36 fix (look up assignee agent name when executionAgentNameKey is null) to npm.

Thanks @HomicideZero.