### PR TITLE
feat: per-company channel routing via config (closes #9)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,6 +42,8 @@ export const DEFAULT_CONFIG = {
   dailyDigestTime: "09:00",
   bidailySecondTime: "17:00",
   tridailyTimes: "07:00,13:00,19:00",
+  companyChannels: {} as Record<string, string>,
+  approvalsChannels: {} as Record<string, string>,
 } as const;
 
 export const DISCORD_API_BASE = "https://discord.com/api/v10";

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -81,6 +81,22 @@ const manifest: PaperclipPluginManifestV1 = {
         description: "Channel ID for approval requests. Falls back to default channel.",
         default: DEFAULT_CONFIG.approvalsChannelId,
       },
+      companyChannels: {
+        type: "object",
+        title: "Per-company channel overrides",
+        description:
+          "Route notifications per Paperclip company. Keys are company UUIDs, values are Discord channel IDs. Applied to every event type that does not have a more specific map. Falls through to the default/global channel when a company is not listed.",
+        additionalProperties: { type: "string" },
+        default: DEFAULT_CONFIG.companyChannels,
+      },
+      approvalsChannels: {
+        type: "object",
+        title: "Per-company approvals channel overrides",
+        description:
+          "Route approval.created events to a specific channel per company. Keys are company UUIDs, values are Discord channel IDs. Checked before companyChannels; falls through to approvalsChannelId (global) when unset.",
+        additionalProperties: { type: "string" },
+        default: DEFAULT_CONFIG.approvalsChannels,
+      },
       errorsChannelId: {
         type: "string",
         title: "Errors Channel ID",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -92,6 +92,22 @@ type DiscordConfig = {
   dailyDigestTime: string;
   bidailySecondTime: string;
   tridailyTimes: string;
+  /**
+   * Per-company channel overrides. Keys are Paperclip company UUIDs; values are
+   * Discord channel IDs. When a plugin install serves multiple companies, each
+   * event type routes to the company-specific channel listed here; if a
+   * company is not mapped, the event falls back to the default/global channel.
+   *
+   * Example:
+   *   { "3060c8cb-...": "1490608926423646298", "4427f9e2-...": "1490610083728588950" }
+   */
+  companyChannels?: Record<string, string>;
+  /**
+   * Per-company approval channel overrides. Checked specifically for
+   * `approval.created` events before `companyChannels`. Use this when
+   * different companies have dedicated approvals channels.
+   */
+  approvalsChannels?: Record<string, string>;
 };
 
 type IssueNotificationPayload = Record<string, unknown>;
@@ -128,13 +144,35 @@ async function resolveChannel(
   ctx: PluginContext,
   companyId: string,
   fallback: unknown,
+  channelMap?: Record<string, string>,
 ): Promise<string | null> {
+  // 1. Explicit state override via `/clip connect-channel` (per-company set at runtime).
   const override = await ctx.state.get({
     scopeKind: "company",
     scopeId: companyId,
     stateKey: "discord-channel",
   });
-  return normalizeDiscordId(override) ?? normalizeDiscordId(fallback);
+  if (override) return normalizeDiscordId(override);
+
+  // 2. Event-type-specific per-company map passed by the caller (e.g. approvalsChannels).
+  if (channelMap && companyId && channelMap[companyId]) {
+    return normalizeDiscordId(channelMap[companyId]);
+  }
+
+  // 3. General `companyChannels` map from plugin config — applies to every event type
+  //    that does not have its own specific map.
+  try {
+    const rawConfig = (await ctx.config.get?.()) as DiscordConfig | undefined;
+    const general = rawConfig?.companyChannels;
+    if (general && companyId && general[companyId]) {
+      return normalizeDiscordId(general[companyId]);
+    }
+  } catch {
+    // ctx.config.get may not be available in some SDK versions — fall through silently.
+  }
+
+  // 4. Fall back to whatever the caller passed (topicChannel | overrideChannelId | default).
+  return normalizeDiscordId(fallback);
 }
 
 async function enrichIssueNotificationPayload(
@@ -479,6 +517,7 @@ const plugin = definePlugin({
       event: PluginEvent,
       formatter: (e: PluginEvent, baseUrl?: string) => ReturnType<typeof formatIssueCreated>,
       overrideChannelId?: string,
+      channelMap?: Record<string, string>,
     ) => {
       if (isDuplicate(event.eventId)) {
         ctx.logger.debug(`Skipping duplicate event ${event.eventType} (${event.eventId})`);
@@ -486,7 +525,7 @@ const plugin = definePlugin({
       }
 
       const topicChannel = overrideChannelId ? null : await resolveTopicChannel(event);
-      const channelId = await resolveChannel(ctx, event.companyId, topicChannel || overrideChannelId || config.defaultChannelId);
+      const channelId = await resolveChannel(ctx, event.companyId, topicChannel || overrideChannelId || config.defaultChannelId, channelMap);
       if (!channelId) return;
 
       const message = formatter(event, baseUrl);
@@ -550,7 +589,12 @@ const plugin = definePlugin({
 
     if (config.notifyOnApprovalCreated) {
       ctx.events.on("approval.created", (event: PluginEvent) =>
-        notify(event, formatApprovalCreated, approvalsChannelId ?? undefined),
+        notify(
+          event,
+          formatApprovalCreated,
+          approvalsChannelId ?? undefined,
+          config.approvalsChannels,
+        ),
       );
     }
 


### PR DESCRIPTION
## Summary

Fixes #9 — adds per-company channel routing for multi-tenant Paperclip installs.

## What this changes

Two optional config maps:

- **`companyChannels`** — `Record<companyId, channelId>`, general fallback that applies to every event type after the existing `/clip connect-channel` state override and before the global default.
- **`approvalsChannels`** — `Record<companyId, channelId>`, event-specific map checked FIRST for `approval.created` events, so companies with dedicated approvals channels can route there distinct from their general ops channel.

## Resolution order in `resolveChannel`

1. Explicit state override via `/clip connect-channel` (unchanged)
2. Event-specific `channelMap` param (e.g. `approvalsChannels` for approvals)
3. General `config.companyChannels[companyId]`
4. Caller-provided fallback (topic channel, override, default)

Both maps declared in `instanceConfigSchema` with `additionalProperties: { type: "string" }` so the admin UI renders a proper editor.

## Why a config map and not the existing `/clip connect-channel` state path

The SDK's `ctx.state.set({ scopeKind: "company", scopeId, ... })` writes are not readable back from the same `(scopeKind, scopeId, stateKey)` triple in the SDK versions I run against (v2026.403.0 and v2026.416.0). Filed paperclipai/paperclip#4093 to track. Even after that SDK bug is fixed, a config map is the right tool for fleet-wide routing rules an operator sets once, versus a per-runtime mutation — so both mechanisms are useful together.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 443/443 pass (18 test files, including `company-state-scoping.test.ts` which is unrelated but exercises the scope plumbing I touched)
- [x] Deployed against a 3-company install (Creative Touch / Italian Connection / Phobos Corp) running Paperclip v2026.416.0 — notifications route per-company, approvals route per-company, everything else falls through to `defaultChannelId` when unmapped

## Related

- Closes #9
- Complements #32 (companyId-in-custom_id) — that fix resolves per-company button auth, this resolves per-company notification destinations
- Sibling upstream tracking: paperclipai/paperclip#4093 (state-scope bug)

## @christianlappin

You volunteered on #9 back in 2026-03-29 with essentially this design. I left a comment on the issue earlier today asking if you'd started; no response yet, so I'm opening this to unblock us — happy to collaborate, take edits, or close in favor of your branch if you have one further along.
