### PR TITLE
Handle approval.approved and approval.rejected events to resolve Discord message

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -518,7 +518,8 @@ const plugin = definePlugin({
       formatter: (e: PluginEvent, baseUrl?: string) => ReturnType<typeof formatIssueCreated>,
       overrideChannelId?: string,
       channelMap?: Record<string, string>,
-    ) => {
+      onPosted?: (channelId: string, messageId: string) => Promise<void>,
+    ): Promise<void> => {
       if (isDuplicate(event.eventId)) {
         ctx.logger.debug(`Skipping duplicate event ${event.eventType} (${event.eventId})`);
         return;
@@ -551,6 +552,10 @@ const plugin = definePlugin({
           entityType: "plugin",
           entityId: event.entityId,
         });
+
+        if (onPosted) {
+          await onPosted(channelId, messageId);
+        }
       }
     };
 
@@ -588,14 +593,67 @@ const plugin = definePlugin({
     }
 
     if (config.notifyOnApprovalCreated) {
-      ctx.events.on("approval.created", (event: PluginEvent) =>
-        notify(
+      ctx.events.on("approval.created", async (event: PluginEvent) => {
+        await notify(
           event,
           formatApprovalCreated,
           approvalsChannelId ?? undefined,
           config.approvalsChannels,
-        ),
-      );
+          async (channelId, messageId) => {
+            // Store reverse mapping so decision events can update the original message
+            await ctx.state.set(
+              { scopeKind: "instance", stateKey: `approval_${event.entityId}` },
+              { channelId, messageId },
+            );
+          },
+        );
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ctx.events.on("approval.approved" as any, async (event: PluginEvent) => {
+        const record = await ctx.state.get({
+          scopeKind: "instance",
+          stateKey: `approval_${event.entityId}`,
+        }) as { channelId: string; messageId: string } | null;
+        if (!record) return;
+
+        const decidedBy = event.actorId ?? "";
+        const label = decidedBy ? `✅ Approved by ${decidedBy}` : "✅ Approved";
+        await adapter.editMessage(record.channelId, record.messageId, {
+          embeds: [
+            {
+              title: label,
+              color: COLORS.GREEN,
+              footer: { text: "Paperclip" },
+              timestamp: event.occurredAt,
+            },
+          ],
+          components: [],
+        });
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ctx.events.on("approval.rejected" as any, async (event: PluginEvent) => {
+        const record = await ctx.state.get({
+          scopeKind: "instance",
+          stateKey: `approval_${event.entityId}`,
+        }) as { channelId: string; messageId: string } | null;
+        if (!record) return;
+
+        const decidedBy = event.actorId ?? "";
+        const label = decidedBy ? `❌ Rejected by ${decidedBy}` : "❌ Rejected";
+        await adapter.editMessage(record.channelId, record.messageId, {
+          embeds: [
+            {
+              title: label,
+              color: COLORS.RED,
+              footer: { text: "Paperclip" },
+              timestamp: event.occurredAt,
+            },
+          ],
+          components: [],
+        });
+      });
     }
 
     if (config.notifyOnAgentError) {

--- a/tests/approval-decision.test.ts
+++ b/tests/approval-decision.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Regression tests for approval.approved / approval.rejected event handling.
+//
+// Before the fix:
+//   - PLUGIN_EVENT_TYPES only contained "approval.decided" (never emitted)
+//   - Discord plugin only subscribed to "approval.created" — no handler for
+//     decision events, so Discord messages kept showing active Approve/Reject
+//     buttons after a decision was made
+//
+// After the fix:
+//   - approval.created stores a reverse mapping approval_{id} → {channelId, messageId}
+//   - approval.approved edits the original message to show ✅ Approved
+//   - approval.rejected edits the original message to show ❌ Rejected
+// ---------------------------------------------------------------------------
+
+const { capturedSetups } = vi.hoisted(() => {
+  const capturedSetups: Array<(ctx: any) => Promise<void>> = [];
+  return { capturedSetups };
+});
+
+vi.mock("@paperclipai/plugin-sdk", () => ({
+  definePlugin: (def: any) => {
+    if (def.setup) capturedSetups.push(def.setup);
+    return Object.freeze({ definition: def });
+  },
+  runWorker: vi.fn(),
+}));
+
+import "../src/worker.js";
+
+function getSetup(): (ctx: any) => Promise<void> {
+  if (capturedSetups.length === 0) {
+    throw new Error("setup() was not captured — definePlugin mock may not be active");
+  }
+  return capturedSetups[capturedSetups.length - 1];
+}
+
+function buildPluginContext(configOverrides: Record<string, unknown> = {}) {
+  const eventHandlers = new Map<string, Array<(event: any) => Promise<void>>>();
+  let messageCounter = 0;
+  const stateStore = new Map<string, unknown>();
+  const editedMessages: Array<{ channelId: string; messageId: string; body: any }> = [];
+
+  const defaultConfig: Record<string, unknown> = {
+    discordBotTokenRef: "fake-secret-ref",
+    defaultGuildId: "",
+    defaultChannelId: "ch-approvals",
+    approvalsChannelId: "ch-approvals",
+    errorsChannelId: "",
+    bdPipelineChannelId: "",
+    notifyOnIssueCreated: false,
+    notifyOnIssueDone: false,
+    notifyOnApprovalCreated: true,
+    notifyOnAgentError: false,
+    enableIntelligence: false,
+    intelligenceChannelIds: [],
+    backfillDays: 0,
+    paperclipBaseUrl: "http://localhost:3100",
+    intelligenceRetentionDays: 30,
+    escalationChannelId: "",
+    enableEscalations: false,
+    escalationTimeoutMinutes: 30,
+    maxAgentsPerThread: 5,
+    enableMediaPipeline: false,
+    mediaChannelIds: [],
+    enableCustomCommands: false,
+    enableProactiveSuggestions: false,
+    proactiveScanIntervalMinutes: 15,
+    enableCommands: false,
+    enableInbound: false,
+    topicRouting: false,
+    digestMode: "off",
+    dailyDigestTime: "09:00",
+    bidailySecondTime: "17:00",
+    tridailyTimes: "07:00,13:00,19:00",
+    ...configOverrides,
+  };
+
+  const mockDiscordFetch = vi.fn().mockImplementation(async (url: string, opts: any) => {
+    if (typeof url === "string" && url.includes("/messages/") && opts?.method === "PATCH") {
+      // editMessage call
+      const parts = url.split("/");
+      const msgIdx = parts.indexOf("messages");
+      const messageId = parts[msgIdx + 1];
+      const channelIdx = parts.indexOf("channels");
+      const channelId = parts[channelIdx + 1];
+      editedMessages.push({ channelId, messageId, body: JSON.parse(opts.body) });
+    }
+    return {
+      ok: true,
+      json: async () => ({ id: `msg-${++messageCounter}` }),
+      text: async () => "",
+    };
+  });
+
+  const ctx = {
+    config: { get: vi.fn().mockResolvedValue(defaultConfig) },
+    secrets: { resolve: vi.fn().mockResolvedValue("fake-bot-token") },
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    state: {
+      get: vi.fn().mockImplementation(async (key: { scopeKind: string; scopeId?: string; stateKey: string }) => {
+        const id = `${key.scopeKind}:${key.scopeId ?? ""}:${key.stateKey}`;
+        return stateStore.get(id) ?? null;
+      }),
+      set: vi.fn().mockImplementation(async (key: { scopeKind: string; scopeId?: string; stateKey: string }, value: unknown) => {
+        const id = `${key.scopeKind}:${key.scopeId ?? ""}:${key.stateKey}`;
+        stateStore.set(id, value);
+      }),
+    },
+    metrics: { write: vi.fn().mockResolvedValue(undefined) },
+    activity: { log: vi.fn().mockResolvedValue(undefined) },
+    jobs: { register: vi.fn() },
+    tools: { register: vi.fn() },
+    data: { register: vi.fn() },
+    actions: { register: vi.fn() },
+    events: {
+      subscribe: vi.fn(),
+      emit: vi.fn(),
+      on: vi.fn().mockImplementation((name: string, fn: (event: any) => Promise<void>) => {
+        const handlers = eventHandlers.get(name) || [];
+        handlers.push(fn);
+        eventHandlers.set(name, handlers);
+        return () => {};
+      }),
+    },
+    companies: { list: vi.fn().mockResolvedValue([]) },
+    agents: { list: vi.fn().mockResolvedValue([]), invoke: vi.fn() },
+    issues: {
+      list: vi.fn().mockResolvedValue([]),
+      get: vi.fn().mockResolvedValue(null),
+      listComments: vi.fn().mockResolvedValue([]),
+    },
+    http: { fetch: mockDiscordFetch },
+  } as any;
+
+  return { ctx, eventHandlers, editedMessages, stateStore };
+}
+
+async function emitEvent(
+  eventHandlers: Map<string, Array<(event: any) => Promise<void>>>,
+  eventType: string,
+  event: any,
+) {
+  const handlers = eventHandlers.get(eventType) || [];
+  for (const handler of handlers) {
+    await handler(event);
+  }
+}
+
+function makeApprovalEvent(
+  eventType: string,
+  approvalId: string,
+  opts: { actorId?: string; eventId?: string } = {},
+): any {
+  return {
+    eventId: opts.eventId ?? `evt-${Math.random()}`,
+    eventType,
+    occurredAt: new Date().toISOString(),
+    companyId: "company-1",
+    entityId: approvalId,
+    entityType: "approval",
+    actorId: opts.actorId,
+    payload: { type: "request_board_approval", approvalId },
+  };
+}
+
+describe("approval decision event handling", () => {
+  it("stores reverse mapping when approval.created is posted", async () => {
+    const { ctx, eventHandlers, stateStore } = buildPluginContext();
+    await getSetup()(ctx);
+
+    await emitEvent(eventHandlers, "approval.created", makeApprovalEvent("approval.created", "approval-123", { eventId: "evt-create-1" }));
+
+    const stateKey = "instance::approval_approval-123";
+    const stored = stateStore.get(stateKey) as { channelId: string; messageId: string } | undefined;
+    expect(stored).toBeDefined();
+    expect(stored?.channelId).toBe("ch-approvals");
+    // messageId is whatever Discord assigned — just verify it's a non-empty string
+    expect(stored?.messageId).toMatch(/^msg-\d+$/);
+  });
+
+  it("edits the original message with green embed when approval.approved fires", async () => {
+    const { ctx, eventHandlers, editedMessages, stateStore } = buildPluginContext();
+    await getSetup()(ctx);
+
+    // Post the approval message first
+    await emitEvent(eventHandlers, "approval.created", makeApprovalEvent("approval.created", "approval-456", { eventId: "evt-create-2" }));
+
+    const stored = stateStore.get("instance::approval_approval-456") as { channelId: string; messageId: string };
+    expect(stored).toBeDefined();
+
+    // Fire decision event
+    await emitEvent(eventHandlers, "approval.approved", makeApprovalEvent("approval.approved", "approval-456", { actorId: "user-board" }));
+
+    expect(editedMessages).toHaveLength(1);
+    const edit = editedMessages[0];
+    expect(edit.channelId).toBe("ch-approvals");
+    expect(edit.messageId).toBe(stored.messageId);
+    expect(edit.body.embeds[0].title).toContain("✅");
+    expect(edit.body.embeds[0].title).toContain("user-board");
+    expect(edit.body.embeds[0].color).toBeGreaterThan(0); // green
+    expect(edit.body.components).toEqual([]);
+  });
+
+  it("edits the original message with red embed when approval.rejected fires", async () => {
+    const { ctx, eventHandlers, editedMessages, stateStore } = buildPluginContext();
+    await getSetup()(ctx);
+
+    await emitEvent(eventHandlers, "approval.created", makeApprovalEvent("approval.created", "approval-789", { eventId: "evt-create-3" }));
+    const stored = stateStore.get("instance::approval_approval-789") as { channelId: string; messageId: string };
+    expect(stored).toBeDefined();
+
+    await emitEvent(eventHandlers, "approval.rejected", makeApprovalEvent("approval.rejected", "approval-789", { actorId: "user-board" }));
+
+    expect(editedMessages).toHaveLength(1);
+    const edit = editedMessages[0];
+    expect(edit.channelId).toBe("ch-approvals");
+    expect(edit.messageId).toBe(stored.messageId);
+    expect(edit.body.embeds[0].title).toContain("❌");
+    expect(edit.body.embeds[0].title).toContain("user-board");
+    expect(edit.body.components).toEqual([]);
+  });
+
+  it("does nothing on decision event when no approval.created message was stored", async () => {
+    const { ctx, eventHandlers, editedMessages } = buildPluginContext();
+    await getSetup()(ctx);
+
+    // Fire decision with no prior created event
+    await emitEvent(eventHandlers, "approval.approved", makeApprovalEvent("approval.approved", "approval-unknown", { actorId: "board" }));
+
+    expect(editedMessages).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Fixes #30

## Problem

When an approval was decided (approved or rejected) via the web UI, the Discord message kept showing active Approve/Reject buttons because the plugin only subscribed to `approval.created` — no handler existed for decision events.

The root cause was two-fold:
1. `PLUGIN_EVENT_TYPES` in `@paperclipai/shared` only contained `approval.decided` (which no route ever emits); a companion PR on the core repo adds the correct `approval.approved` and `approval.rejected` event types.
2. This plugin had no handler for those decision events.

## What Changed

**`src/worker.ts`**
- Added `onPosted?: (channelId, messageId) => Promise<void>` callback parameter to `notify()` so callers can capture the message coordinates without changing the function's return type
- Extended the `approval.created` handler to use that callback to store a reverse mapping `approval_{approvalId}` → `{ channelId, messageId }` in plugin state
- Added `approval.approved` handler: looks up the stored mapping and calls `adapter.editMessage()` with a green ✅ embed and empty components (removes buttons)
- Added `approval.rejected` handler: same, but red ❌ embed

**`tests/approval-decision.test.ts`** — new file with 4 regression tests:
- Verifies that `approval.created` stores the reverse mapping
- Verifies `approval.approved` edits the original message with green embed and no buttons
- Verifies `approval.rejected` edits the original message with red embed and no buttons
- Verifies that decision events with no prior `created` mapping are a no-op

## Verification

```
npm run build    # passes
npm test         # 447/447 tests pass
```

## Note on event type compatibility

The `approval.approved`/`approval.rejected` subscription uses a cast (`as any`) because the local SDK's `PLUGIN_EVENT_TYPES` doesn't include those types yet — a companion PR on `paperclipai/paperclip` (PR #4134) adds them. Once that PR is merged and the SDK version is bumped, the cast can be removed.