### PR TITLE
fix(company-resolver): honour /clip connect in multi-company setups

### DIFF
--- a/src/company-resolver.ts
+++ b/src/company-resolver.ts
@@ -3,10 +3,26 @@ import type { PluginContext } from "@paperclipai/plugin-sdk";
 /**
  * Lazy company-ID resolver — avoids startup-time API calls that can crash
  * worker activation. The resolved value is cached after the first successful call.
+ *
+ * Multi-company fix: check `company_default` instance state (written by
+ * `/clip connect`) before falling back to list-based resolution. The
+ * connected company is NOT cached so that `/clip connect` changes take effect
+ * immediately without restarting the plugin.
  */
 let _cachedCompanyId: string | null = null;
 
 export async function resolveCompanyId(ctx: PluginContext): Promise<string> {
+  // Check if a guild-level default was set via /clip connect — always re-read
+  // so that switching companies works without a plugin restart.
+  try {
+    const connected = await ctx.state.get({ scopeKind: "instance", stateKey: "company_default" });
+    if (connected?.companyId) {
+      return connected.companyId as string;
+    }
+  } catch {
+    // state API unavailable at this call site — fall through to list-based resolution
+  }
+
   if (_cachedCompanyId) return _cachedCompanyId;
   try {
     const companies = await ctx.companies.list({ limit: 1 });


### PR DESCRIPTION
## Problem

In multi-company Paperclip instances, `resolveCompanyId()` ignores the company set via `/clip connect`. It calls `ctx.companies.list({ limit: 1 })` and caches the result globally, so `/clip status`, `/clip issues`, `/clip budget`, `/clip agents`, and job-level resolvers always return data for whichever company happens to be first in the API response — not the one the user connected to.

Root cause: `handleConnect` in `commands.ts` correctly writes the selected company to plugin state (`company_default` instance key), but `resolveCompanyId` never reads that state.

Reported in #31 (original report was about escalation buttons, which #32 already fixed by embedding `companyId` in the button `custom_id`). This PR fixes the remaining command-path variant.

## Fix

Before falling back to `ctx.companies.list()`, read the `company_default` instance state written by `/clip connect`. If a company is connected, return it immediately without caching so that switching companies with `/clip connect` takes effect immediately — no plugin restart needed.

## Behaviour change

| Scenario | Before | After |
|----------|--------|-------|
| Single company | Unchanged — list fallback still applies | Unchanged |
| Multi-company, no `/clip connect` | Returns `companies[0]` (non-deterministic) | Same (unchanged) |
| Multi-company, after `/clip connect GreenPath` | Still returns `companies[0]` (bug) | Returns the connected company ✓ |
| `/clip connect` to a different company | Requires restart to take effect (bug) | Takes effect immediately ✓ |

## Testing

Verified locally against a 3-company Paperclip instance running `v0.9.0`. After applying the patch to `dist/company-resolver.js`:

1. `/clip connect GreenPath` → subsequent `/clip status` shows GreenPath data ✓
2. `/clip connect OtherCo` → subsequent `/clip status` shows OtherCo data without restart ✓
3. Single-company setup unchanged ✓

Closes #31 (command-path variant).