### PR TITLE
docs: fix README pointing to non-existent "Settings → Secrets" page

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,12 @@ curl -X POST http://127.0.0.1:3100/api/plugins/install \
 2. Add a bot to the application and copy the bot token
 3. Enable the MESSAGE CONTENT privileged intent (for intelligence scanning)
 4. Invite the bot to your server with `applications.commands` and `bot` scopes
-5. In Paperclip, go to **Settings -> Secrets -> Create new secret**, paste your bot token as the secret value, and copy the resulting UUID
+5. In Paperclip, create a **company secret** holding your bot token, by either:
+
+   - **UI:** Open any agent's **Configuration → Environment variables**, enter a name (e.g. `discord-bot-token`) and the bot token as the value, then click **Create / Seal**. The secret is created at the **company level** (not bound to that agent — despite the agent-context UI) and the returned UUID can be used from any plugin in the company.
+   - **REST API:** `POST /api/companies/{companyId}/secrets` with body `{"name": "discord-bot-token", "value": "<your-bot-token>", "provider": "local_encrypted"}`. The response contains the secret's UUID.
+
+   Copy the resulting secret UUID — you'll paste it into `discordBotTokenRef` in the next step.
 6. Configure the plugin with the secret UUID in `discordBotTokenRef`, your guild ID, and channel ID
 
 ## Configuration
@@ -250,13 +255,12 @@ Brings the Discord plugin to full parity with the Telegram plugin across 14 feat
 
 ### v0.2.1
 
-The `discordBotTokenRef` field now requires a Paperclip secret reference (a UUID), not the raw token value. If you previously entered your raw bot token in the field, follow these steps to migrate:
+The `discordBotTokenRef` field now requires a Paperclip secret reference (a UUID), not the raw token value. If you previously entered a raw bot token in the field, follow these steps to migrate:
 
-1. Go to **Settings -> Secrets -> Create new secret**
-2. Paste your Discord bot token as the secret value and save
-3. Copy the resulting UUID
-4. Open **Plugin Settings for Discord Bot** and paste the UUID into "Discord Bot Token"
-5. Save and restart the plugin
+1. Create a company secret holding your bot token using one of the paths in the [Setup](#setup) section above (UI or REST API).
+2. Copy the returned secret UUID.
+3. Open **Plugin Settings for Discord Bot** and paste the UUID into "Discord Bot Token".
+4. Save and restart the plugin.
 
 The plugin will fail to activate if a raw token (non-UUID) is entered in the field.
 


### PR DESCRIPTION
## Summary

Fixes the README's `Settings → Secrets → Create new secret` instruction, which points to a non-existent page in current Paperclip.

## What changed

Replaces the bogus path in **Setup** and **Migration** sections with two correct paths (verified against `paperclipai/paperclip` master):

- **UI:** Agent Configuration → Environment variables → enter name (e.g. `discord-bot-token`) + bot token → create/seal. Inline creation via `ui/src/components/AgentConfigForm.tsx:1127` (`onCreateSecret`). The secret is **company-scoped** despite the agent-context UI.
- **REST API:** `POST /api/companies/{companyId}/secrets` with `{"name": "discord-bot-token", "value": ..., "provider": "local_encrypted"}`.

The Migration section was shortened to reference Setup rather than duplicate the path — easier to keep in sync if the upstream UX changes.

## Verification

- Verified upstream truth at `paperclipai/paperclip` master (commit `0e1a5828`): no `/settings/secrets` route in `ui/src/App.tsx`, no standalone `Secrets.tsx` page; `secretsApi.create` is called from `AgentConfigForm.tsx:1127`.
- Cross-plugin scope: same fix in coordinated PRs for `paperclip-plugin-{telegram,slack}`.

## Related

- mvanhorn/paperclip-plugin-telegram#23 (PR coming, same fix shape)
- mvanhorn/paperclip-plugin-slack#23 (PR coming, same fix shape)
- ACP plugin unaffected (no secret-creation instruction in its README)

Closes #44

---
<sub><em>**[@superbiche](https://github.com/superbiche)** · co-maintainer · drafted with Claude Opus 4.7, reviewed before posting; the voice and decisions are mine.</em></sub>