### PR TITLE
docs: callout post-#5429 plugin secret-ref kill switch on paperclipai master

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ curl -X POST http://127.0.0.1:3100/api/plugins/install \
   -d '{"packageName":"paperclip-plugin-discord"}'
 ```
 
+> **Note — `paperclipai` master, post [#5429](https://github.com/paperclipai/paperclip/pull/5429) (2026-05-09):**
+> The new Secrets Manager ships with a temporary kill switch on plugin secret-ref UUIDs while a company-scoped `plugin_config` follow-up lands. If you're running paperclipai master, plugin activation will fail with `Plugin secret references are disabled until company-scoped plugin config lands`, and `POST /api/plugins/:id/config` returns HTTP 422 for configs containing secret-ref UUIDs (e.g. `discordBotTokenRef`). This is intentional fail-closed mitigation (PAP-2394 — see the [upstream plan doc](https://github.com/paperclipai/paperclip/blob/master/doc/plans/2026-04-26-plugin-secret-ref-company-scope.md)). Until the follow-up lands, pin to the last paperclipai release before #5429. This callout will be removed once secret-ref resolution is restored.
+
 ## Setup
 
 1. Create a Discord application at https://discord.com/developers/applications


### PR DESCRIPTION
## Summary

Transitional README callout warning users on paperclipai master that plugin secret-ref UUIDs are currently disabled due to a fail-closed mitigation merged ~hours ago in upstream paperclipai/paperclip#5429.

## Context

#5429 ("Add secrets provider vaults and remote import") shipped the new Secrets Manager UI. Alongside the additive vault feature, the PR includes a deliberate kill switch on plugin secret-ref resolution to mitigate a cross-company exposure path (PAP-2394):

- `server/src/services/plugin-secrets-handler.ts:235` — `resolve()` now throws `Plugin secret references are disabled until company-scoped plugin config lands`
- `server/src/routes/plugins.ts:1950` — `POST /api/plugins/:pluginId/config` returns HTTP 422 on configs with UUID-shaped secret refs

The plan doc (`doc/plans/2026-04-26-plugin-secret-ref-company-scope.md`) frames this as the intended steady state until the company-scoped `plugin_config` follow-up PR lands. No soft-warning bypass by design.

## What changed

- `README.md`: blockquote callout inserted immediately before §Setup. Links to #5429 + the upstream plan doc. Mentions the `discordBotTokenRef` field affected.

## Plan

The callout is transitional — removed in a follow-up PR once upstream restores secret-ref resolution.

## Cross-plugin scope

Same callout shipping in coordinated PRs for `paperclip-plugin-{telegram,slack}`. ACP unaffected (no secret-ref config field).

---
<sub><em>**[@superbiche](https://github.com/superbiche)** · co-maintainer · drafted with Claude Opus 4.7, reviewed before posting; the voice and decisions are mine.</em></sub>