### PR TITLE
fix(commands): ignore slash commands not owned by this plugin

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -381,6 +381,18 @@ async function handleSlashCommand(
     );
   }
 
+  // Ignore slash commands not owned by this plugin. The Discord bot token may be
+  // shared with other applications (e.g. OpenClaw's discord plugin handles /status,
+  // /agents, etc.), and Discord delivers INTERACTION_CREATE to every connected
+  // client on the gateway. Without this guard, non-/clip commands fall through to
+  // the "Missing subcommand" branch below and respond with a misleading
+  // "Try `/clip status`" message, effectively hijacking the other plugin's reply.
+  // This plugin owns "/clip" (and "/acp", handled above); everything else is
+  // someone else's responsibility.
+  if (data.name !== "clip") {
+    return;
+  }
+
   const subcommand = data.options?.[0];
   if (!subcommand) {
     return respondToInteraction({

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -85,6 +85,31 @@ describe("handleInteraction", () => {
     );
     expect(ctx.metrics.write).toHaveBeenCalledWith("discord_commands_handled", 1);
   });
+
+  it("ignores slash commands not owned by this plugin (e.g. /status)", async () => {
+    // Discord bot tokens are sometimes shared across applications. The gateway
+    // dispatches INTERACTION_CREATE to every connected client, so this plugin
+    // must ignore commands it does not own — otherwise it falls through to the
+    // "Missing subcommand. Try `/clip status`." branch and hijacks the
+    // legitimate handler's reply.
+    const ctx = makeCtx();
+    const result = await handleInteraction(
+      ctx,
+      { type: 2, data: { name: "status", options: [] } },
+      defaultCmdCtx,
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("ignores arbitrary unknown slash commands (e.g. /foo)", async () => {
+    const ctx = makeCtx();
+    const result = await handleInteraction(
+      ctx,
+      { type: 2, data: { name: "foo", options: [{ name: "bar" }] } },
+      defaultCmdCtx,
+    );
+    expect(result).toBeUndefined();
+  });
 });
 
 describe("/clip status", () => {


### PR DESCRIPTION
## Summary

When a Discord bot token is shared across multiple applications (e.g. another bot — in my case [OpenClaw](https://openclaw.com)'s discord plugin — uses the same token), Discord's gateway dispatches \`INTERACTION_CREATE\` to **every** connected client. \`handleSlashCommand\` currently handles \`acp\` explicitly but then falls through into the generic subcommand parser for any other \`data.name\`, including commands this plugin does not own (\`/status\`, \`/agents\`, \`/help\`, etc.).

The result is that for every \`/status\` (or other non-\`/clip\`) invocation Discord sends, this plugin races to reply:

> Missing subcommand. Try \`/clip status\`.

…hijacking the legitimate plugin's reply window, since Discord only honors the first response to an interaction token.

## Fix

Add an early \`return\` when \`data.name !== \"clip\"\` (the \`acp\` case is already handled above). This makes the plugin scope-aware and a good neighbor on a shared token.

\`\`\`ts
// src/commands.ts (handleSlashCommand)
if (data.name === \"acp\") { ... }

+ if (data.name !== \"clip\") {
+   return; // not ours
+ }

  const subcommand = data.options?.[0];
\`\`\`

## Test plan

- [x] Two new regression tests in \`tests/commands.test.ts\`:
  - \`handleInteraction\` ignores \`/status\` (returns \`undefined\`, no metrics write triggered after the \`data.name !== \"clip\"\` guard)
  - \`handleInteraction\` ignores arbitrary \`/foo\`
- [x] Existing 447 tests still pass (\`pnpm test\` reports **449 passed**).
- [x] Built locally via \`pnpm install\` (postinstall \`tsc\`) — clean compile.
- [x] Verified live in production deployment: \`/status\` had been intermittently replying \"Missing subcommand. Try \`/clip status\`\" depending on which bot won the race; with this patch, the other plugin's response renders cleanly every time.

## Notes

- No public API change. Both \`acp\` and \`clip\` are still handled normally.
- The guard intentionally does **not** respond to the user — silently ignoring is correct behavior when the command is not addressed at this plugin.