### PR TITLE
fix(session-registry): drop custom taskKey from sessions.create to avoid upstream contract mismatch

### DIFF
--- a/src/session-registry.ts
+++ b/src/session-registry.ts
@@ -274,8 +274,8 @@ export async function spawnAgentInThread(
   let transport: TransportKind = "native";
 
   try {
+    // Do not pass a custom `taskKey` — host's sendMessage/list/close filter on `plugin:${pluginKey}:session:%`, so any user-supplied key becomes invisible to subsequent SDK calls.
     const session = await ctx.agents.sessions.create(agentId, companyId, {
-      taskKey: `discord-thread-${threadId}`,
       reason: `Spawned in Discord thread for: ${taskPrompt.slice(0, 200)}`,
     });
     sessionId = session.sessionId;


### PR DESCRIPTION
Fixes #49. Related: paperclipai/paperclip#6156 (upstream root cause).

## Summary

`spawnAgentInThread` was passing `taskKey: \`discord-thread-${threadId}\`` to `ctx.agents.sessions.create()`. This trips a contract inconsistency in PaperClip's plugin-host services (filed upstream): `create` honors arbitrary `taskKey` values, but `sendMessage`/`list`/`close` require the `plugin:${pluginKey}:session:%` prefix. Custom keys orphan the session — `sendMessage` immediately throws `Session not found`, falling through to the ACP fallback which has no consumer in default installations.

The custom `taskKey` was decorative — grepped and never read elsewhere in the plugin. Dropping it lets the host generate the prefixed default form so downstream ops succeed.

## Implementation

```diff
  try {
+   // Do not pass a custom `taskKey` — host's sendMessage/list/close filter on
+   // `plugin:${pluginKey}:session:%`, so any user-supplied key becomes invisible
+   // to subsequent SDK calls.
    const session = await ctx.agents.sessions.create(agentId, companyId, {
-     taskKey: `discord-thread-${threadId}`,
      reason: `Spawned in Discord thread for: ${taskPrompt.slice(0, 200)}`,
    });
```

The inline comment documents the upstream constraint so a future contributor doesn't re-add it.

## Verification

- `npm run typecheck` — clean
- `npx vitest run tests/session-registry.test.ts` — 28/28 pass
- End-to-end in our deployment against PaperClip v2026.403.0: before this fix, `/acp spawn` logs `host handler error method=agents.sessions.sendMessage err: "Session not found"` and the worker logs `Native session create failed, trying ACP fallback` followed by `transport=acp`; after the fix, `transport=native` and the agent receives the prompt and responds in the spawned thread.

## Future

Once paperclipai/paperclip#6156 lands upstream, this defensive workaround can be reverted in favor of restoring the thread-ID-bearing `taskKey` for traceability. Until then, defense in depth is appropriate.