### PR TITLE
fix(formatters): fall back to issue.title in headline when identifier is null

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -48,7 +48,7 @@ function resolveBaseUrl(baseUrl?: string): string | null {
 
 export function formatIssueCreated(event: PluginEvent, baseUrl?: string): DiscordMessage {
   const p = event.payload as Payload;
-  const identifier = String(p.identifier ?? event.entityId);
+  const identifier = String(p.identifier ?? p.title ?? event.entityId);
   const title = String(p.title ?? "Untitled");
   const description = p.description ? String(p.description) : null;
   const status = p.status ? String(p.status) : null;
@@ -124,7 +124,7 @@ export function formatIssueCreated(event: PluginEvent, baseUrl?: string): Discor
 
 export function formatIssueDone(event: PluginEvent, baseUrl?: string): DiscordMessage {
   const p = event.payload as Payload;
-  const identifier = String(p.identifier ?? event.entityId);
+  const identifier = String(p.identifier ?? p.title ?? event.entityId);
   const title = String(p.title ?? "") || identifier;
   const status = p.status ? String(p.status) : null;
   const priority = p.priority ? String(p.priority) : null;

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -64,6 +64,13 @@ describe("formatIssueCreated", () => {
     const viewBtn = msg.components?.[0]?.components?.find((c) => c.label === "View Issue");
     expect(viewBtn).toBeUndefined();
   });
+
+  it("falls back to title in headline when identifier is null", () => {
+    const msg = formatIssueCreated(
+      makeEvent({ entityId: "uuid-abc", payload: { title: "Fix login bug" } }),
+    );
+    expect(msg.embeds?.[0]?.title).toBe("Issue Created: Fix login bug");
+  });
 });
 
 describe("formatIssueDone", () => {
@@ -108,6 +115,13 @@ describe("formatIssueDone", () => {
       makeEvent({ entityId: "entity-abc" }),
     );
     expect(msg.embeds?.[0]?.description).toBe("**entity-abc** is now done.");
+  });
+
+  it("falls back to title in headline when identifier is null", () => {
+    const msg = formatIssueDone(
+      makeEvent({ entityId: "uuid-abc", payload: { title: "Fix login bug" } }),
+    );
+    expect(msg.embeds?.[0]?.title).toBe("✅ Issue Completed: Fix login bug");
   });
 });
 


### PR DESCRIPTION
Fixes #48.

## Summary

`formatIssueCreated` and `formatIssueDone` derived the embed headline from `p.identifier ?? event.entityId`. When `payload.identifier` is null (common for issues created outside the standard identifier-generating flow — direct DB inserts, custom origin paths, plugin SDK paths that bypass identifier generation), the headline showed the raw UUID:

```
✅ Issue Completed: 5ad541b7-f87a-4876-8360-1edb6af46ec3
```

Fall back to `payload.title` before the final UUID fallback so operators get a readable headline:

```
✅ Issue Completed: What is 9 plus 1?
```

## Implementation

Both formatters got the same fallback chain (`identifier → title → entityId`) for consistency:

```diff
- const identifier = String(p.identifier ?? event.entityId);
+ const identifier = String(p.identifier ?? p.title ?? event.entityId);
```

Applied at both `formatIssueCreated` (line 51) and `formatIssueDone` (line 127). The issue body for #48 explicitly called out applying the same fix to `formatIssueCreated`, so both are addressed in one logical change.

## Tests added

Two new tests in `tests/formatters.test.ts`:

- `formatIssueCreated falls back to title in headline when identifier is null` — asserts `Issue Created: Fix login bug` when only `payload.title` is set.
- `formatIssueDone falls back to title in headline when identifier is null` — asserts `✅ Issue Completed: Fix login bug` when only `payload.title` is set.

The existing test `falls back to entityId when both title and identifier are missing` still passes — entityId remains the final fallback when neither identifier nor title is present.

## Verification

- `npm run typecheck` — clean
- `npx vitest run tests/formatters.test.ts` — 91/91 pass (was 89; added 2)

## Backwards compatibility

Pure widening of the fallback chain. Callers that previously got the entityId UUID in the headline (because both `identifier` and `title` were missing) still get the entityId. The only behavioral change is for the in-between case where `title` is set but `identifier` is null — those now get a readable headline instead of a UUID.