### PR TITLE
fix(paperclip-fetch): throw PaperclipFetchError on non-2xx so auth and routing failures surface

### DIFF
--- a/src/paperclip-fetch.ts
+++ b/src/paperclip-fetch.ts
@@ -17,16 +17,40 @@
  * header carrying a board API key. Pass `apiKey` to attach it. In
  * `local_trusted` deployments unauthenticated requests are implicitly
  * promoted to `board`, so `apiKey` can be omitted.
+ *
+ * Throws on non-2xx responses with a `PaperclipFetchError` carrying
+ * `status` + `headers` so `withRetry` can recognize retryable statuses
+ * (429/500/502/503) without callers needing to call `throwOnRetryableStatus`
+ * inside their `withRetry` callback.
  */
-export function paperclipFetch(
+export class PaperclipFetchError extends Error {
+  status: number;
+  headers: Headers;
+  constructor(message: string, status: number, headers: Headers) {
+    super(message);
+    this.name = "PaperclipFetchError";
+    this.status = status;
+    this.headers = headers;
+  }
+}
+
+export async function paperclipFetch(
   url: string,
   init?: RequestInit,
   apiKey?: string,
 ): Promise<Response> {
-  if (!apiKey) return fetch(url, init);
   const headers = new Headers(init?.headers);
-  if (!headers.has("Authorization")) {
+  if (apiKey && !headers.has("Authorization")) {
     headers.set("Authorization", `Bearer ${apiKey}`);
   }
-  return fetch(url, { ...init, headers });
+  const response = await fetch(url, { ...init, headers });
+  if (!response.ok) {
+    const body = await response.text().catch(() => "<unreadable>");
+    throw new PaperclipFetchError(
+      `paperclipFetch ${init?.method ?? "GET"} ${url} → ${response.status} ${response.statusText}: ${body.slice(0, 200)}`,
+      response.status,
+      response.headers,
+    );
+  }
+  return response;
 }

--- a/tests/paperclip-fetch.test.ts
+++ b/tests/paperclip-fetch.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { paperclipFetch, PaperclipFetchError } from "../src/paperclip-fetch.js";
+
+describe("paperclipFetch", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("returns the Response unchanged on 2xx", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response('{"ok":true}', { status: 200, statusText: "OK" }),
+    );
+    const r = await paperclipFetch("http://x/y", { method: "GET" });
+    expect(r.status).toBe(200);
+    expect(await r.json()).toEqual({ ok: true });
+  });
+
+  it("throws PaperclipFetchError with status + body on 401", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response("Malformed JWT: expected 3 parts", { status: 401, statusText: "Unauthorized" }),
+    );
+    await expect(
+      paperclipFetch("http://x/y", { method: "POST" }, "test-key"),
+    ).rejects.toThrow(/401 Unauthorized.*Malformed JWT/);
+    try {
+      await paperclipFetch("http://x/y", { method: "POST" }, "test-key");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PaperclipFetchError);
+      expect((err as PaperclipFetchError).status).toBe(401);
+    }
+  });
+
+  it("attaches status + headers so withRetry can detect retryable statuses", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response("rate limited", {
+        status: 429,
+        statusText: "Too Many Requests",
+        headers: { "Retry-After": "2" },
+      }),
+    );
+    try {
+      await paperclipFetch("http://x/y");
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PaperclipFetchError);
+      const pErr = err as PaperclipFetchError;
+      expect(pErr.status).toBe(429);
+      expect(pErr.headers.get("Retry-After")).toBe("2");
+    }
+  });
+
+  it("attaches Bearer auth header when apiKey is provided", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response("", { status: 200 }));
+    global.fetch = fetchSpy;
+    await paperclipFetch("http://x/y", {}, "my-api-key");
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer my-api-key");
+  });
+
+  it("does not overwrite an existing Authorization header", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response("", { status: 200 }));
+    global.fetch = fetchSpy;
+    await paperclipFetch(
+      "http://x/y",
+      { headers: { Authorization: "Bearer pre-set" } },
+      "my-api-key",
+    );
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer pre-set");
+  });
+
+  it("truncates very long error bodies to keep error messages bounded", async () => {
+    const longBody = "x".repeat(5000);
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(longBody, { status: 500, statusText: "Internal Server Error" }),
+    );
+    try {
+      await paperclipFetch("http://x/y");
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg.length).toBeLessThan(500);
+      expect(msg).toMatch(/500 Internal Server Error/);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #43.

## Summary

`paperclipFetch` returned the `Response` object regardless of status, and `fetch()` doesn't throw on non-2xx — only on network errors. The caller in `worker.ts:422` (Discord-reply → issue-comment routing) discards the Response, silently treating 401/403/404 as success: the metric increments, the info log fires, and the operator has no idea anything failed. That's the exact symptom in issue #43 — "Routed Discord reply to issue comment" logged but no comment ever created in the DB. We hit the same symptom in our deployment, traced it to a `paperclipBaseUrl` misconfig pointing at port `:3100` (auth-proxy, JWT-only) instead of `:3099` (native), which returned `401 Malformed JWT: expected 3 parts`.

## Implementation

`paperclipFetch` now throws on non-2xx. The thrown error is a typed `PaperclipFetchError` carrying `status` + `headers` so `withRetry`'s retry-on-{429,500,502,503} logic continues to work — callers using `withRetry(() => paperclipFetch(...))` get automatic retries on retryable statuses without needing `throwOnRetryableStatus` inside the callback.

```ts
export class PaperclipFetchError extends Error {
  status: number;
  headers: Headers;
  // ...
}

export async function paperclipFetch(url, init?, apiKey?) {
  // ... headers setup ...
  const response = await fetch(url, { ...init, headers });
  if (!response.ok) {
    const body = await response.text().catch(() => "<unreadable>");
    throw new PaperclipFetchError(
      `paperclipFetch ${method} ${url} → ${status} ${statusText}: ${body.slice(0, 200)}`,
      response.status,
      response.headers,
    );
  }
  return response;
}
```

## Caller audit

All 6 call sites already wrap `paperclipFetch` in try/catch:

| File:line | Pattern | After this change |
|---|---|---|
| `worker.ts:422` | fire-and-forget, try/catch | **Fix lands here** — error is now caught and logged with status/body |
| `commands.ts:575` (approve) | `withRetry` + `throwOnRetryableStatus` + `if (!resp.ok)` | `withRetry` still retries on 429/500/502/503 via typed error; explicit `.ok` check becomes a defensive no-op |
| `commands.ts:1163` (approve button) | same as above | same as above |
| `commands.ts:1214` (reject button) | same as above | same as above |
| `workflow-engine.ts:130` (get issue) | `if (!resp.ok) return { ok: false, ... }` | returns `{ ok: false, error: <richer-message> }` with full status + body |
| `workflow-engine.ts:251` (create issue) | same as above | same as above |

No caller relied on receiving a non-2xx Response. Grep clean.

## Tests added

New `tests/paperclip-fetch.test.ts` with 6 tests:

- Returns Response unchanged on 2xx
- Throws `PaperclipFetchError` with status + body on 401
- Attaches status + `Retry-After` header on 429 so `withRetry` detects it
- Attaches Bearer auth when `apiKey` provided
- Preserves existing `Authorization` header
- Truncates very long error bodies (keeps error message bounded)

## Verification

- `npm run typecheck` — clean
- `npm run test` — 455/455 pass (added 6; was 449)

After this fix, the reproducer from issue #43 produces an error log like:

```
[ERROR] Failed to route inbound message {"error": "paperclipFetch POST http://localhost:3100/api/issues/.../comments → 401 Unauthorized: Malformed JWT..."}
```

instead of the misleading info log.

## Backwards compatibility

`paperclipFetch` signature unchanged. Callers that previously expected to receive a non-2xx Response no longer can — but no such callers exist (audit above). Callers using `withRetry` continue to get retries on the same statuses, now triggered by the typed error from `paperclipFetch` itself rather than the in-callback `throwOnRetryableStatus`. The `throwOnRetryableStatus` calls inside `withRetry` callbacks are now redundant but kept (defensive; no behavior change). A follow-up could remove them.