### PR TITLE
fix(worker,formatters): enrich agent.run.* events with agent + issue context

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -410,9 +410,21 @@ export function formatBudgetWarning(data: BudgetWarningData): DiscordMessage {
   };
 }
 
+// Pick the best human-readable name for an agent run notification.
+// Paperclip's agent.run.* events set entityId = run id (not agent id), so the
+// previous `event.entityId` fallback produced run UUIDs as agent names. Prefer
+// the actor (agent id from the event envelope) over entityId, and only show a
+// generic label as a last resort.
+function resolveRunAgentLabel(event: PluginEvent, p: Payload): string {
+  if (typeof p.agentName === "string" && p.agentName) return p.agentName;
+  if (typeof p.agentId === "string" && p.agentId) return p.agentId;
+  if (typeof event.actorId === "string" && event.actorId) return event.actorId;
+  return "Agent";
+}
+
 export function formatAgentRunStarted(event: PluginEvent): DiscordMessage {
   const p = event.payload as Payload;
-  const agentName = String(p.agentName ?? event.entityId);
+  const agentName = resolveRunAgentLabel(event, p);
   const issueIdentifier = p.issueIdentifier ? String(p.issueIdentifier) : null;
   const issueTitle = p.issueTitle ? String(p.issueTitle) : null;
 
@@ -435,7 +447,7 @@ export function formatAgentRunStarted(event: PluginEvent): DiscordMessage {
 
 export function formatAgentRunFinished(event: PluginEvent): DiscordMessage {
   const p = event.payload as Payload;
-  const agentName = String(p.agentName ?? event.entityId);
+  const agentName = resolveRunAgentLabel(event, p);
   const issueIdentifier = p.issueIdentifier ? String(p.issueIdentifier) : null;
   const issueTitle = p.issueTitle ? String(p.issueTitle) : null;
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -112,6 +112,15 @@ type DiscordConfig = {
 
 type IssueNotificationPayload = Record<string, unknown>;
 
+type AgentRunNotificationPayload = Record<string, unknown> & {
+  runId?: string | null;
+  agentId?: string | null;
+  agentName?: string | null;
+  issueId?: string | null;
+  issueIdentifier?: string | null;
+  issueTitle?: string | null;
+};
+
 // EscalationRecord is imported from ./escalation-state.js
 
 interface EscalationCreatedPayload {
@@ -291,6 +300,64 @@ async function resolveIssueCompanyIdForNotification(
   }
 
   return candidates[0] ?? null;
+}
+
+export async function enrichRunPayload(
+  ctx: PluginContext,
+  event: PluginEvent,
+): Promise<AgentRunNotificationPayload> {
+  const payload: AgentRunNotificationPayload = { ...(event.payload as AgentRunNotificationPayload) };
+
+  // Paperclip's agent.run.* events set:
+  //   entityType: "heartbeat_run", entityId: <run id>, actorId: <agent id>
+  //   payload: { runId, agentId, issueId, status, ... }
+  // The formatter wants agentName + issueIdentifier + issueTitle in the payload.
+  const companyId =
+    (typeof event.companyId === "string" && event.companyId) || null;
+  const agentId =
+    (typeof payload.agentId === "string" && payload.agentId) ||
+    (typeof event.actorId === "string" && event.actorId) ||
+    null;
+  const issueId =
+    (typeof payload.issueId === "string" && payload.issueId) || null;
+
+  if (!companyId) return payload;
+
+  try {
+    if (!payload.agentName && agentId) {
+      const agents = (await ctx.agents.list({ companyId })) as Array<{
+        id: string;
+        name: string;
+      }>;
+      const match = agents.find((a) => a.id === agentId);
+      if (match?.name) payload.agentName = match.name;
+    }
+
+    if (issueId && (!payload.issueIdentifier || !payload.issueTitle)) {
+      const issue = (await ctx.issues.get(issueId, companyId)) as {
+        id: string;
+        identifier?: string | null;
+        title?: string | null;
+      } | null;
+      if (issue) {
+        if (!payload.issueIdentifier) {
+          payload.issueIdentifier = issue.identifier ?? issue.id;
+        }
+        if (!payload.issueTitle && issue.title) {
+          payload.issueTitle = issue.title;
+        }
+      }
+    }
+  } catch (error) {
+    ctx.logger.debug("Agent run notification enrichment failed", {
+      runId: typeof payload.runId === "string" ? payload.runId : event.entityId,
+      agentId,
+      issueId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return payload;
 }
 
 const plugin = definePlugin({
@@ -662,12 +729,14 @@ const plugin = definePlugin({
       );
     }
 
-    ctx.events.on("agent.run.started", (event: PluginEvent) =>
-      notify(event, formatAgentRunStarted, bdPipelineChannelId ?? undefined),
-    );
-    ctx.events.on("agent.run.finished", (event: PluginEvent) =>
-      notify(event, formatAgentRunFinished, bdPipelineChannelId ?? undefined),
-    );
+    ctx.events.on("agent.run.started", async (event: PluginEvent) => {
+      const payload = await enrichRunPayload(ctx, event);
+      await notify({ ...event, payload }, formatAgentRunStarted, bdPipelineChannelId ?? undefined);
+    });
+    ctx.events.on("agent.run.finished", async (event: PluginEvent) => {
+      const payload = await enrichRunPayload(ctx, event);
+      await notify({ ...event, payload }, formatAgentRunFinished, bdPipelineChannelId ?? undefined);
+    });
 
     // ===================================================================
     // Phase 1: Escalation - human-in-the-loop support

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -185,9 +185,31 @@ describe("formatAgentRunStarted", () => {
     expect(msg.embeds?.[0]?.description).toContain("BD Agent");
   });
 
-  it("falls back to entityId when agentName missing", () => {
-    const msg = formatAgentRunStarted(makeEvent({ entityId: "fallback-agent" }));
-    expect(msg.embeds?.[0]?.description).toContain("fallback-agent");
+  it("falls back to payload.agentId when agentName missing (NOT entityId, which is the run id)", () => {
+    const msg = formatAgentRunStarted(
+      makeEvent({
+        entityId: "run-uuid-should-not-appear",
+        payload: { agentId: "agent-uuid" },
+      }),
+    );
+    expect(msg.embeds?.[0]?.description).toContain("agent-uuid");
+    expect(msg.embeds?.[0]?.description).not.toContain("run-uuid-should-not-appear");
+  });
+
+  it("falls back to event.actorId when neither agentName nor payload.agentId is present", () => {
+    const msg = formatAgentRunStarted(
+      makeEvent({
+        entityId: "run-uuid",
+        // PluginEvent's actorId is the agent id per Paperclip's emission contract
+        actorId: "actor-agent-uuid",
+      } as Partial<PluginEvent>),
+    );
+    expect(msg.embeds?.[0]?.description).toContain("actor-agent-uuid");
+  });
+
+  it("falls back to generic 'Agent' label when no identifying field is available", () => {
+    const msg = formatAgentRunStarted(makeEvent({ entityId: "run-uuid" }));
+    expect(msg.embeds?.[0]?.description).toBe("**Agent** has started a new run.");
   });
 
   it("includes task context when issueIdentifier is provided", () => {

--- a/tests/run-event-enrichment.test.ts
+++ b/tests/run-event-enrichment.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from "vitest";
+import { enrichRunPayload } from "../src/worker.js";
+import type { PluginEvent } from "@paperclipai/plugin-sdk";
+
+// Minimal ctx shaped like the live PluginContext for the fields enrichRunPayload uses.
+// Tests only stub agents.list, issues.get, logger.debug, and companies.list.
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    agents: {
+      list: vi.fn().mockResolvedValue([]),
+    },
+    issues: {
+      get: vi.fn().mockResolvedValue(null),
+    },
+    companies: {
+      list: vi.fn().mockResolvedValue([]),
+    },
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+// Build an agent.run.* event in the shape Paperclip emits today.
+// See heartbeat.ts:publishRunLifecyclePluginEvent — entityId is the run id,
+// actorId/payload.agentId is the agent id, payload.issueId is optional.
+function makeRunEvent(overrides: Partial<PluginEvent> = {}): PluginEvent {
+  return {
+    eventType: "agent.run.started",
+    eventId: "evt-1",
+    companyId: "co-1",
+    entityId: "run-uuid",
+    entityType: "heartbeat_run",
+    actorId: "agent-uuid",
+    occurredAt: "2026-05-25T19:00:00Z",
+    payload: { runId: "run-uuid", agentId: "agent-uuid", status: "running" },
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe("enrichRunPayload", () => {
+  it("looks up agentName from agents.list when payload.agentName is missing", async () => {
+    const ctx = makeCtx({
+      agents: {
+        list: vi.fn().mockResolvedValue([
+          { id: "other-agent", name: "Decoy" },
+          { id: "agent-uuid", name: "Scribe" },
+        ]),
+      },
+    });
+    const result = await enrichRunPayload(ctx, makeRunEvent());
+    expect(result.agentName).toBe("Scribe");
+    expect(ctx.agents.list).toHaveBeenCalledWith({ companyId: "co-1" });
+  });
+
+  it("preserves an existing payload.agentName and does not call agents.list", async () => {
+    const ctx = makeCtx({
+      agents: { list: vi.fn().mockResolvedValue([]) },
+    });
+    const result = await enrichRunPayload(
+      ctx,
+      makeRunEvent({ payload: { agentId: "agent-uuid", agentName: "Pre-set" } }),
+    );
+    expect(result.agentName).toBe("Pre-set");
+    expect(ctx.agents.list).not.toHaveBeenCalled();
+  });
+
+  it("falls back to event.actorId when payload.agentId is absent", async () => {
+    const ctx = makeCtx({
+      agents: {
+        list: vi
+          .fn()
+          .mockResolvedValue([{ id: "actor-agent", name: "FromActor" }]),
+      },
+    });
+    const result = await enrichRunPayload(
+      ctx,
+      makeRunEvent({
+        actorId: "actor-agent",
+        payload: { runId: "run-uuid", status: "running" },
+      }),
+    );
+    expect(result.agentName).toBe("FromActor");
+  });
+
+  it("looks up issue identifier and title from issues.get when payload.issueId is present", async () => {
+    const ctx = makeCtx({
+      issues: {
+        get: vi
+          .fn()
+          .mockResolvedValue({ id: "iss-1", identifier: "TUM-42", title: "Ship Klippy fixes" }),
+      },
+    });
+    const result = await enrichRunPayload(
+      ctx,
+      makeRunEvent({
+        payload: { runId: "run-uuid", agentId: "agent-uuid", issueId: "iss-1" },
+      }),
+    );
+    expect(ctx.issues.get).toHaveBeenCalledWith("iss-1", "co-1");
+    expect(result.issueIdentifier).toBe("TUM-42");
+    expect(result.issueTitle).toBe("Ship Klippy fixes");
+  });
+
+  it("does not call issues.get when payload.issueId is null (no associated issue)", async () => {
+    const ctx = makeCtx();
+    const result = await enrichRunPayload(
+      ctx,
+      makeRunEvent({
+        payload: { runId: "run-uuid", agentId: "agent-uuid", issueId: null },
+      }),
+    );
+    expect(ctx.issues.get).not.toHaveBeenCalled();
+    expect(result.issueIdentifier).toBeUndefined();
+    expect(result.issueTitle).toBeUndefined();
+  });
+
+  it("returns payload unchanged and skips lookups when companyId is missing", async () => {
+    const ctx = makeCtx({
+      agents: { list: vi.fn().mockResolvedValue([]) },
+      issues: { get: vi.fn().mockResolvedValue(null) },
+    });
+    const result = await enrichRunPayload(
+      ctx,
+      makeRunEvent({ companyId: undefined, payload: { agentId: "agent-uuid", issueId: "iss-1" } } as Partial<PluginEvent>),
+    );
+    expect(ctx.agents.list).not.toHaveBeenCalled();
+    expect(ctx.issues.get).not.toHaveBeenCalled();
+    expect(result.agentName).toBeUndefined();
+    expect(result.issueIdentifier).toBeUndefined();
+  });
+
+  it("swallows lookup errors and returns the unenriched payload (notifications must not be blocked)", async () => {
+    const ctx = makeCtx({
+      agents: {
+        list: vi.fn().mockRejectedValue(new Error("agent list exploded")),
+      },
+    });
+    const result = await enrichRunPayload(ctx, makeRunEvent());
+    expect(ctx.logger.debug).toHaveBeenCalled();
+    expect(result.runId).toBe("run-uuid"); // original payload preserved
+    expect(result.agentName).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

`agent.run.started` and `agent.run.finished` notifications render as
`Run Started: <uuid>` instead of `Run Started: <agentName> — TASK-x`.
Real example from a production Klippy install:

> **Run Started: 9a1e5f01-4e4f-458b-a493-ccc265b4bc06**
> `9a1e5f01-4e4f-458b-a493-ccc265b4bc06` has started a new run.

Two root causes, both in this plugin:

1. The run-event handlers in `worker.ts` call `notify(event, ...)` directly,
   unlike `issue.created` / `issue.updated` which call
   `enrichIssueNotificationPayload(ctx, event)` first. Paperclip's event
   payload for `agent.run.*` carries `agentId`, `issueId`, `runId` — but
   not `agentName`, `issueIdentifier`, `issueTitle`, which is what the
   formatter actually reads (see [`server/src/services/heartbeat.ts`
   `publishRunLifecyclePluginEvent`](https://github.com/paperclipai/paperclip/blob/main/server/src/services/heartbeat.ts)).
2. The formatter's fallback when `payload.agentName` was missing was
   `event.entityId`. For `agent.run.*` events Paperclip sets
   `entityType: "heartbeat_run"` and `entityId: <run id>` — so the
   "fallback agent name" was actually the run UUID, producing the
   `Run Started: <random-uuid>` messages.

## Fix

- New `enrichRunPayload(ctx, event)` helper in `worker.ts`, parallel to
  the existing `enrichIssueNotificationPayload`. Looks up the agent via
  `ctx.agents.list({companyId})` and the issue via
  `ctx.issues.get(issueId, companyId)`, merging `agentName`,
  `issueIdentifier`, `issueTitle` into the payload before `notify()` runs.
  Errors are swallowed with a debug log so notifications are never
  blocked by transient lookup failures.
- `agent.run.started` and `agent.run.finished` handlers now
  `await enrichRunPayload(ctx, event)` before calling
  `notify({...event, payload}, ...)`.
- Formatter fallback hierarchy is now
  `payload.agentName → payload.agentId → event.actorId → "Agent"` —
  never the run id.

## Tests

- New `tests/run-event-enrichment.test.ts` (7 cases) covers the helper
  end-to-end: agent lookup, pre-set `agentName` preserved without an
  extra API call, `actorId` fallback, issue lookup when `issueId`
  present, skip when `issueId` is null, skip when `companyId` missing,
  and the error-swallowing path.
- `formatters.test.ts`: replaces the now-incorrect "falls back to
  entityId" test (entityId is a run id, not an agent id) with the new
  fallback-chain cases.
- 456/456 tests passing; `npm run typecheck` and `npm run build` clean.

## Out of scope (separate PR)

Gateway heartbeat sending before the WebSocket opens (`gateway.js:208`
`Sent before connected`) caused worker crashes that made the plugin
fall through to "interactions will only work via webhook" mode and
silently broke `/clip` inbound for two weeks in the same install. That's
a real bug too, but unrelated to event enrichment — fix coming in a
follow-up PR.