### PR TITLE
feat(voice): Phase 1 — war-room voice client skeleton (STT inbound)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,42 @@
       "name": "paperclip-plugin-discord",
       "version": "0.9.1",
       "license": "MIT",
+      "dependencies": {
+        "@discordjs/voice": "^0.18.0",
+        "libsodium-wrappers": "^0.7.13",
+        "prism-media": "^1.3.5",
+        "ws": "^8.18.0"
+      },
       "devDependencies": {
         "@paperclipai/plugin-sdk": "^2026.403.0",
         "@paperclipai/shared": "^2026.403.0",
+        "@types/libsodium-wrappers": "^0.7.14",
+        "@types/ws": "^8.5.13",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
       },
       "peerDependencies": {
         "@paperclipai/plugin-sdk": "*",
         "@paperclipai/shared": "*"
+      }
+    },
+    "node_modules/@discordjs/voice": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.18.0.tgz",
+      "integrity": "sha512-BvX6+VJE5/vhD9azV9vrZEt9hL1G+GlOdsQaVl5iv9n87fkXjf3cSwllhR3GdaUC8m6dqT8umXIWtn3yCu4afg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/ws": "^8.5.12",
+        "discord-api-types": "^0.37.103",
+        "prism-media": "^1.3.5",
+        "tslib": "^2.6.3",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -914,6 +941,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/libsodium-wrappers": {
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.14.tgz",
+      "integrity": "sha512-5Kv68fXuXK0iDuUir1WPGw2R9fOZUlYlSAa0ztMcL0s0BfIDTqg9GXz8K30VJpPP3sxWhbolnQma2x+/TfkzDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1104,6 +1156,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/discord-api-types": {
+      "version": "0.37.120",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.120.tgz",
+      "integrity": "sha512-7xpNK0EiWjjDFp2nAhHXezE4OUWm7s1zhc/UXXN6hnFFU8dfoPHgV0Hx0RPiCa3ILRpdeh152icc68DGCyXYIw==",
+      "license": "MIT"
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
@@ -1213,6 +1271,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/libsodium": {
+      "version": "0.7.16",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.16.tgz",
+      "integrity": "sha512-3HrzSPuzm6Yt9aTYCDxYEG8x8/6C0+ag655Y7rhhWZM9PT4NpdnbqlzXhGZlDnkgR6MeSTnOt/VIyHLs9aSf+Q==",
+      "license": "ISC"
+    },
+    "node_modules/libsodium-wrappers": {
+      "version": "0.7.16",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.16.tgz",
+      "integrity": "sha512-Gtr/WBx4dKjvRL1pvfwZqu7gO6AfrQ0u9vFL+kXihtHf6NfkROR8pjYWn98MFDI3jN19Ii1ZUfPR9afGiPyfHg==",
+      "license": "ISC",
+      "dependencies": {
+        "libsodium": "^0.7.16"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -1320,6 +1393,32 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prism-media": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
+      "integrity": "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@discordjs/opus": ">=0.8.0 <1.0.0",
+        "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
+        "node-opus": "^0.3.3",
+        "opusscript": "^0.0.8"
+      },
+      "peerDependenciesMeta": {
+        "@discordjs/opus": {
+          "optional": true
+        },
+        "ffmpeg-static": {
+          "optional": true
+        },
+        "node-opus": {
+          "optional": true
+        },
+        "opusscript": {
+          "optional": true
+        }
       }
     },
     "node_modules/rollup": {
@@ -1472,6 +1571,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1485,6 +1590,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.1",
@@ -1672,6 +1783,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -19,11 +19,19 @@
     "@paperclipai/plugin-sdk": "*",
     "@paperclipai/shared": "*"
   },
+  "dependencies": {
+    "@discordjs/voice": "^0.18.0",
+    "prism-media": "^1.3.5",
+    "libsodium-wrappers": "^0.7.13",
+    "ws": "^8.18.0"
+  },
   "devDependencies": {
     "@paperclipai/plugin-sdk": "^2026.403.0",
     "@paperclipai/shared": "^2026.403.0",
     "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "vitest": "^3.0.0",
+    "@types/ws": "^8.5.13",
+    "@types/libsodium-wrappers": "^0.7.14"
   },
   "files": [
     "dist/"

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -7,6 +7,7 @@ const MAX_CONSECUTIVE_FAILURES = 5;
 const MAX_BACKOFF_MS = 60_000;
 const DEFAULT_RECONNECT_MS = 5000;
 const GUILD_INTENT = 1;
+const GUILD_VOICE_STATES_INTENT = 128;
 const GUILD_MESSAGES_INTENT = 512;
 const MESSAGE_CONTENT_INTENT = 32768;
 
@@ -44,12 +45,61 @@ export interface MessageCreateEvent {
   };
 }
 
+/** VOICE_STATE_UPDATE dispatch event payload (Discord Gateway op 0, t = VOICE_STATE_UPDATE). */
+export interface VoiceStateUpdateEvent {
+  guild_id?: string;
+  channel_id: string | null;
+  user_id: string;
+  session_id: string;
+  // Other fields exist (member, mute, deaf, ...) but @discordjs/voice only needs the above.
+  [key: string]: unknown;
+}
+
+/** VOICE_SERVER_UPDATE dispatch event payload (Discord Gateway op 0, t = VOICE_SERVER_UPDATE). */
+export interface VoiceServerUpdateEvent {
+  token: string;
+  guild_id: string;
+  endpoint: string | null;
+  [key: string]: unknown;
+}
+
+/** Arbitrary gateway payload (used by voice.sendPayload to emit op 4 voice state updates). */
+export interface GatewaySendPayload {
+  op: number;
+  d: unknown;
+}
+
 type InteractionHandler = (interaction: InteractionCreateEvent) => Promise<unknown>;
 type MessageHandler = (message: MessageCreateEvent) => Promise<void>;
+type VoiceStateUpdateHandler = (event: VoiceStateUpdateEvent) => void;
+type VoiceServerUpdateHandler = (event: VoiceServerUpdateEvent) => void;
 
 export interface GatewayOptions {
   listenForMessages?: boolean;
   includeMessageContent?: boolean;
+  /** Enable GUILD_VOICE_STATES intent + VOICE_STATE_UPDATE/VOICE_SERVER_UPDATE dispatch. */
+  enableVoice?: boolean;
+}
+
+/**
+ * Voice-related primitives surfaced on the gateway handle when `enableVoice` is true.
+ * Designed to plug straight into a custom @discordjs/voice DiscordGatewayAdapterCreator.
+ * See docs/superpowers/research/2026-05-28-plugin-sdk-voice-feasibility.md in the
+ * MRTek repo for the architecture rationale.
+ */
+export interface GatewayVoiceHandle {
+  /** Send a raw gateway payload (typically op 4 voice-state-update). Returns true if sent. */
+  sendPayload(payload: GatewaySendPayload): boolean;
+  /** Subscribe to VOICE_STATE_UPDATE dispatch events. */
+  onVoiceStateUpdate(handler: VoiceStateUpdateHandler): void;
+  /** Subscribe to VOICE_SERVER_UPDATE dispatch events. */
+  onVoiceServerUpdate(handler: VoiceServerUpdateHandler): void;
+}
+
+export interface GatewayHandle {
+  close: () => void;
+  /** Present when `options.enableVoice` was true at connect time. */
+  voice?: GatewayVoiceHandle;
 }
 
 export async function respondViaCallback(
@@ -90,7 +140,7 @@ export async function connectGateway(
   onInteraction: InteractionHandler,
   onMessage?: MessageHandler,
   options: GatewayOptions = {},
-): Promise<{ close: () => void }> {
+): Promise<GatewayHandle> {
   if (typeof WebSocket === "undefined") {
     ctx.logger.warn(
       "WebSocket is not available in this environment (requires Node.js >= 21). " +
@@ -116,10 +166,18 @@ export async function connectGateway(
   let lastHeartbeatIntervalMs = 41250;
   const listenForMessages = options.listenForMessages ?? Boolean(onMessage);
   const includeMessageContent = options.includeMessageContent ?? listenForMessages;
+  const enableVoice = options.enableVoice ?? false;
   const intents =
     GUILD_INTENT |
+    (enableVoice ? GUILD_VOICE_STATES_INTENT : 0) |
     (listenForMessages ? GUILD_MESSAGES_INTENT : 0) |
     (includeMessageContent ? MESSAGE_CONTENT_INTENT : 0);
+
+  // Voice dispatch subscriber lists — populated by external consumers (the voice
+  // module) via the `voice` handle returned below. Filled in once the gateway
+  // is connected and VOICE_STATE_UPDATE / VOICE_SERVER_UPDATE events arrive.
+  const voiceStateUpdateHandlers: VoiceStateUpdateHandler[] = [];
+  const voiceServerUpdateHandlers: VoiceServerUpdateHandler[] = [];
 
   function getReconnectDelay(): number {
     if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
@@ -209,6 +267,32 @@ export async function connectGateway(
               ctx.logger.error("Gateway message handler error", {
                 error: error instanceof Error ? error.message : String(error),
               });
+            }
+          }
+
+          if (payload.t === "VOICE_STATE_UPDATE" && enableVoice) {
+            const event = payload.d as VoiceStateUpdateEvent;
+            for (const handler of voiceStateUpdateHandlers) {
+              try {
+                handler(event);
+              } catch (error) {
+                ctx.logger.error("Voice state update handler error", {
+                  error: error instanceof Error ? error.message : String(error),
+                });
+              }
+            }
+          }
+
+          if (payload.t === "VOICE_SERVER_UPDATE" && enableVoice) {
+            const event = payload.d as VoiceServerUpdateEvent;
+            for (const handler of voiceServerUpdateHandlers) {
+              try {
+                handler(event);
+              } catch (error) {
+                ctx.logger.error("Voice server update handler error", {
+                  error: error instanceof Error ? error.message : String(error),
+                });
+              }
             }
           }
           break;
@@ -313,7 +397,7 @@ export async function connectGateway(
 
   connect(gatewayUrl, false);
 
-  return {
+  const handle: GatewayHandle = {
     close: () => {
       closed = true;
       cleanup();
@@ -322,6 +406,26 @@ export async function connectGateway(
       }
     },
   };
+
+  if (enableVoice) {
+    handle.voice = {
+      sendPayload(payload: GatewaySendPayload): boolean {
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify(payload));
+          return true;
+        }
+        return false;
+      },
+      onVoiceStateUpdate(handler: VoiceStateUpdateHandler): void {
+        voiceStateUpdateHandlers.push(handler);
+      },
+      onVoiceServerUpdate(handler: VoiceServerUpdateHandler): void {
+        voiceServerUpdateHandlers.push(handler);
+      },
+    };
+  }
+
+  return handle;
 }
 
 async function getGatewayUrl(ctx: PluginContext, token: string): Promise<string | null> {

--- a/src/voice/client.ts
+++ b/src/voice/client.ts
@@ -1,0 +1,151 @@
+/**
+ * War-room voice client (Phase 1, STT inbound only).
+ *
+ * Joins a Discord voice channel via @discordjs/voice using the custom
+ * gateway adapter from ./discord-adapter.ts. For each speaker, listens
+ * for an Opus stream that ends after 800 ms of silence (the silence
+ * detection IS the VAD — no separate VAD library), decodes to PCM via
+ * prism-media, transcribes via Deepgram, and posts the transcript to
+ * the war-room text channel via the @Michael (voice) webhook.
+ *
+ * Out of scope for Phase 1: TTS outbound (Phase 2), per-agent voice
+ * lookup (Phase 2), cost guard (Phase 3), latency CI checks (Phase 4).
+ */
+
+import {
+  joinVoiceChannel,
+  EndBehaviorType,
+  VoiceConnectionStatus,
+  entersState,
+  type VoiceConnection,
+} from "@discordjs/voice";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import prism from "prism-media";
+
+import { DeepgramSTTAdapter } from "./stt-deepgram.js";
+import { WebhookTextChannelRelay } from "./text-channel-relay.js";
+import type { STTAdapter, TextChannelRelay, VoiceClientConfig } from "./types.js";
+
+const DEFAULT_SILENCE_MS = 800;
+const PCM_SAMPLE_RATE = 48_000;
+const PCM_BYTES_PER_SECOND = PCM_SAMPLE_RATE * 2; // 16-bit mono
+const MIN_UTTERANCE_SEC = 0.2;
+const CONNECTION_READY_TIMEOUT_MS = 5_000;
+
+export class WarRoomVoiceClient {
+  private connection: VoiceConnection | null = null;
+  private readonly ctx: PluginContext;
+  private readonly config: VoiceClientConfig;
+  private readonly stt: STTAdapter;
+  private readonly relay: TextChannelRelay;
+  private readonly silenceMs: number;
+
+  constructor(
+    ctx: PluginContext,
+    config: VoiceClientConfig,
+    stt?: STTAdapter,
+    relay?: TextChannelRelay,
+  ) {
+    this.ctx = ctx;
+    this.config = config;
+    this.stt = stt ?? new DeepgramSTTAdapter({ apiKey: config.deepgramApiKey });
+    this.relay =
+      relay ?? new WebhookTextChannelRelay({ webhookUrl: config.textChannelWebhookUrl });
+    this.silenceMs = config.utteranceEndSilenceMs ?? DEFAULT_SILENCE_MS;
+  }
+
+  /** Join the configured voice channel and start listening. */
+  async start(): Promise<void> {
+    this.connection = joinVoiceChannel({
+      channelId: this.config.voiceChannelId,
+      guildId: this.config.guildId,
+      adapterCreator: this.config.voiceAdapterCreator,
+      selfDeaf: false,
+      selfMute: true, // Phase 1 is inbound-only
+    });
+
+    await entersState(
+      this.connection,
+      VoiceConnectionStatus.Ready,
+      CONNECTION_READY_TIMEOUT_MS,
+    );
+
+    const receiver = this.connection.receiver;
+
+    receiver.speaking.on("start", (userId) => {
+      this.handleUtterance(userId).catch((err) => {
+        this.ctx.logger.error("voice: utterance handling failed", {
+          userId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    });
+
+    this.ctx.logger.info("voice: war-room voice client started", {
+      guildId: this.config.guildId,
+      channelId: this.config.voiceChannelId,
+    });
+  }
+
+  /** Disconnect and clean up. */
+  stop(): void {
+    if (this.connection) {
+      this.connection.destroy();
+      this.connection = null;
+      this.ctx.logger.info("voice: war-room voice client stopped");
+    }
+  }
+
+  private async handleUtterance(userId: string): Promise<void> {
+    if (!this.connection) return;
+
+    const opusStream = this.connection.receiver.subscribe(userId, {
+      end: {
+        behavior: EndBehaviorType.AfterSilence,
+        duration: this.silenceMs,
+      },
+    });
+
+    const decoder = new prism.opus.Decoder({
+      frameSize: 960,
+      channels: 1,
+      rate: PCM_SAMPLE_RATE,
+    });
+
+    const chunks: Buffer[] = [];
+    return new Promise<void>((resolve) => {
+      opusStream
+        .pipe(decoder)
+        .on("data", (chunk: Buffer) => chunks.push(chunk))
+        .on("end", async () => {
+          const pcm = Buffer.concat(chunks);
+          const durationSec = pcm.length / PCM_BYTES_PER_SECOND;
+
+          if (durationSec < MIN_UTTERANCE_SEC) {
+            // Too short to be a real utterance — likely a click or wakeword false-positive.
+            resolve();
+            return;
+          }
+
+          try {
+            const transcript = await this.stt.transcribeUtterance(pcm);
+            await this.relay.postTranscript(transcript, { durationSec });
+          } catch (err) {
+            this.ctx.logger.error("voice: STT or relay failed for utterance", {
+              userId,
+              durationSec: durationSec.toFixed(2),
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+          resolve();
+        })
+        .on("error", (err: Error) => {
+          this.ctx.logger.error("voice: decode error", {
+            userId,
+            error: err.message,
+          });
+          resolve();
+        });
+    });
+  }
+}

--- a/src/voice/discord-adapter.ts
+++ b/src/voice/discord-adapter.ts
@@ -1,0 +1,53 @@
+/**
+ * Bridge between paperclip-plugin-discord's gateway primitives and
+ * @discordjs/voice's expected DiscordGatewayAdapter interface.
+ *
+ * @discordjs/voice doesn't ship with a built-in gateway — every consumer
+ * has to provide an adapter that knows how to (a) send op-4 voice-state
+ * updates and (b) deliver VOICE_STATE_UPDATE + VOICE_SERVER_UPDATE events.
+ * Our `gateway.ts` exposes exactly those primitives via the `voice` handle
+ * (introduced in Phase 1 Task 1.5).
+ *
+ * See ../../../docs/superpowers/research/2026-05-28-plugin-sdk-voice-feasibility.md
+ * (in the MRTek repo) for the architecture rationale.
+ *
+ * Known Phase 1 limitation: handlers registered via gatewayVoice.onVoice*Update
+ * cannot currently be removed (gateway handler list is append-only). For Phase 1
+ * the bot joins one voice channel for the plugin's lifetime, so this doesn't
+ * leak. If we add reconnect/rejoin semantics in later phases, add a remove-handler
+ * primitive to gateway.ts and call it from destroy() below.
+ */
+
+import type { DiscordGatewayAdapterCreator } from "@discordjs/voice";
+
+import type { GatewayVoiceHandle } from "../gateway.js";
+
+// @discordjs/voice declares its dispatch-data types internally (via discord-api-types)
+// but doesn't re-export them. We use Parameters<typeof methods.onVoice*Update>[0]
+// to read them off the function signatures we pass to — this keeps the cast
+// honest without importing an internal type.
+export function createPluginDiscordAdapter(
+  gatewayVoice: GatewayVoiceHandle,
+): DiscordGatewayAdapterCreator {
+  return (methods) => {
+    type StateData = Parameters<typeof methods.onVoiceStateUpdate>[0];
+    type ServerData = Parameters<typeof methods.onVoiceServerUpdate>[0];
+
+    gatewayVoice.onVoiceStateUpdate((event) => {
+      methods.onVoiceStateUpdate(event as unknown as StateData);
+    });
+    gatewayVoice.onVoiceServerUpdate((event) => {
+      methods.onVoiceServerUpdate(event as unknown as ServerData);
+    });
+
+    return {
+      sendPayload(payload) {
+        return gatewayVoice.sendPayload(payload);
+      },
+      destroy() {
+        // No-op: handler list is append-only in gateway.ts today.
+        // See file header note.
+      },
+    };
+  };
+}

--- a/src/voice/index.ts
+++ b/src/voice/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Public exports for the war-room voice subsystem.
+ * See ../../docs/superpowers/specs/2026-05-28-war-room-voice-design.md
+ * (in the MRTek repo).
+ */
+
+export { WarRoomVoiceClient } from "./client.js";
+export { createPluginDiscordAdapter } from "./discord-adapter.js";
+export { DeepgramSTTAdapter } from "./stt-deepgram.js";
+export { WebhookTextChannelRelay } from "./text-channel-relay.js";
+export type {
+  STTAdapter,
+  TextChannelRelay,
+  UtteranceFinalized,
+  VoiceClientConfig,
+} from "./types.js";

--- a/src/voice/stt-deepgram.ts
+++ b/src/voice/stt-deepgram.ts
@@ -1,0 +1,89 @@
+/**
+ * Deepgram streaming STT adapter.
+ *
+ * One WebSocket per utterance. Send raw 16-bit PCM as binary frames,
+ * then send `{"type":"Finalize"}` as a text frame to flush. Read JSON
+ * messages until one carries `is_final: true` with the final transcript.
+ *
+ * API reference: https://developers.deepgram.com/docs/streaming
+ */
+
+import { WebSocket } from "ws";
+
+import type { STTAdapter } from "./types.js";
+
+interface DeepgramConfig {
+  apiKey: string;
+  /** Override the WS base URL; useful for tests. Default: wss://api.deepgram.com */
+  baseUrl?: string;
+  /** Deepgram model. Default: nova-2 */
+  model?: string;
+}
+
+export class DeepgramSTTAdapter implements STTAdapter {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly model: string;
+
+  constructor(cfg: DeepgramConfig) {
+    this.apiKey = cfg.apiKey;
+    this.baseUrl = cfg.baseUrl ?? "wss://api.deepgram.com";
+    this.model = cfg.model ?? "nova-2";
+  }
+
+  async transcribeUtterance(pcm: Buffer): Promise<string> {
+    const url =
+      `${this.baseUrl}/v1/listen` +
+      `?encoding=linear16&sample_rate=48000&channels=1` +
+      `&model=${encodeURIComponent(this.model)}&punctuate=true&interim_results=false`;
+
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(url, {
+        headers: { Authorization: `Token ${this.apiKey}` },
+      });
+
+      let finalTranscript: string | null = null;
+
+      const cleanup = () => {
+        try {
+          ws.close();
+        } catch {
+          // noop
+        }
+      };
+
+      ws.on("open", () => {
+        ws.send(pcm, { binary: true });
+        ws.send(JSON.stringify({ type: "Finalize" }));
+      });
+
+      ws.on("message", (data, isBinary) => {
+        if (isBinary) return; // Deepgram doesn't send binary back
+        try {
+          const msg = JSON.parse(data.toString());
+          if (
+            msg.is_final === true &&
+            msg.channel?.alternatives?.[0]?.transcript !== undefined
+          ) {
+            finalTranscript = String(msg.channel.alternatives[0].transcript);
+            cleanup();
+          }
+        } catch {
+          // ignore non-JSON or malformed; rely on close/error path
+        }
+      });
+
+      ws.on("close", () => {
+        if (finalTranscript !== null) {
+          resolve(finalTranscript);
+        } else {
+          reject(new Error("Deepgram WS closed with no final transcript"));
+        }
+      });
+
+      ws.on("error", (err) => {
+        reject(err);
+      });
+    });
+  }
+}

--- a/src/voice/text-channel-relay.ts
+++ b/src/voice/text-channel-relay.ts
@@ -1,0 +1,68 @@
+/**
+ * POST utterance transcripts to the war-room text channel via webhook,
+ * surfaced as "Michael (voice)" so existing Alfred routing picks them up
+ * exactly as if Michael had typed them.
+ *
+ * Discord webhook payload shape: { content, username, avatar_url? }.
+ * Success = 204 No Content. We retry once on 5xx; hard-fail 4xx.
+ *
+ * Empty / whitespace-only transcripts are skipped — nothing meaningful
+ * was said and posting noise to the war-room defeats the audit-trail value.
+ */
+
+import type { TextChannelRelay } from "./types.js";
+
+interface RelayConfig {
+  webhookUrl: string;
+  /** Display username for the webhook posts. Default: "Michael (voice)" */
+  username?: string;
+}
+
+export class WebhookTextChannelRelay implements TextChannelRelay {
+  private readonly webhookUrl: string;
+  private readonly username: string;
+
+  constructor(cfg: RelayConfig) {
+    this.webhookUrl = cfg.webhookUrl;
+    this.username = cfg.username ?? "Michael (voice)";
+  }
+
+  async postTranscript(
+    text: string,
+    _metadata: { durationSec: number },
+  ): Promise<void> {
+    const trimmed = text.trim();
+    if (trimmed.length === 0) {
+      // Skip empty/whitespace — nothing meaningful was said.
+      return;
+    }
+
+    const body = JSON.stringify({
+      content: trimmed,
+      username: this.username,
+    });
+
+    // First attempt
+    let resp = await fetch(this.webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+
+    // Retry once on 5xx
+    if (resp.status >= 500 && resp.status < 600) {
+      resp = await fetch(this.webhookUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      });
+    }
+
+    if (!resp.ok) {
+      const errBody = await resp.text().catch(() => "<no body>");
+      throw new Error(
+        `webhook POST failed: ${resp.status} ${resp.statusText} — ${errBody}`,
+      );
+    }
+  }
+}

--- a/src/voice/types.ts
+++ b/src/voice/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared types for the war-room voice client (Phase 1, STT-inbound only).
+ * Spec: ../../../docs/superpowers/specs/2026-05-28-war-room-voice-design.md
+ *       (in the MRTek mrt-ai-agent-platform repo)
+ */
+
+import type { DiscordGatewayAdapterCreator } from "@discordjs/voice";
+
+export interface VoiceClientConfig {
+  /** Discord guild (server) ID. */
+  guildId: string;
+  /** Discord voice channel ID to join on startup. */
+  voiceChannelId: string;
+  /** Webhook URL in the war-room text channel for posting transcripts as @Michael (voice). */
+  textChannelWebhookUrl: string;
+  /** Deepgram API key. */
+  deepgramApiKey: string;
+  /** Silence duration (ms) that ends an utterance. Default: 800. */
+  utteranceEndSilenceMs?: number;
+  /** Voice connection adapter from the host SDK / gateway. See voice/discord-adapter.ts. */
+  voiceAdapterCreator: DiscordGatewayAdapterCreator;
+}
+
+export interface UtteranceFinalized {
+  /** Discord user ID who spoke. */
+  userId: string;
+  /** Transcript text (final, post-VAD-endpoint). */
+  text: string;
+  /** Approximate utterance duration in seconds (computed from PCM length). */
+  durationSec: number;
+  /** ISO timestamp at finalize. */
+  finalizedAt: string;
+}
+
+export interface STTAdapter {
+  /**
+   * Send a single utterance (raw 16-bit PCM at 48 kHz mono) and return the final transcript.
+   * Throws on transport failure or non-2xx close. Caller decides retry policy.
+   */
+  transcribeUtterance(pcm: Buffer): Promise<string>;
+}
+
+export interface TextChannelRelay {
+  /** Post a transcript message to the war-room text channel as @Michael (voice). */
+  postTranscript(text: string, metadata: { durationSec: number }): Promise<void>;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -449,6 +449,24 @@ const plugin = definePlugin({
       config.enableProactiveSuggestions === true ||
       config.enableIntelligence === true;
 
+    // --- Phase 1 war-room voice: enabled only if all env vars set ---
+    // Voice startup is gated on env vars (not plugin config) for Phase 1 — the
+    // operator wires DEEPGRAM_API_KEY, WAR_ROOM_GUILD_ID, WAR_ROOM_VOICE_CHANNEL_ID,
+    // and MICHAEL_VOICE_WEBHOOK_URL on the container; if any are absent, voice
+    // initializes nothing (text routing keeps working).
+    const voiceEnv = {
+      guildId: process.env.WAR_ROOM_GUILD_ID,
+      voiceChannelId: process.env.WAR_ROOM_VOICE_CHANNEL_ID,
+      webhookUrl: process.env.MICHAEL_VOICE_WEBHOOK_URL,
+      deepgramApiKey: process.env.DEEPGRAM_API_KEY,
+    };
+    const voiceEnabled = !!(
+      voiceEnv.guildId &&
+      voiceEnv.voiceChannelId &&
+      voiceEnv.webhookUrl &&
+      voiceEnv.deepgramApiKey
+    );
+
     // --- Gateway connection for real-time interaction handling ---
     const gateway = await connectGateway(
       ctx,
@@ -460,10 +478,51 @@ const plugin = definePlugin({
       {
         listenForMessages: gatewayNeedsMessages,
         includeMessageContent: gatewayNeedsMessages,
+        enableVoice: voiceEnabled,
       },
     );
 
+    // --- Phase 1 voice client startup ---
+    // Failures here are isolated — voice errors must not crash the plugin or
+    // affect text routing. See docs/superpowers/specs/2026-05-28-war-room-voice-design.md
+    // §6 "Voice failure never blocks text."
+    let voiceClientStop: (() => void) | null = null;
+    if (voiceEnabled && gateway.voice) {
+      try {
+        const { WarRoomVoiceClient, createPluginDiscordAdapter } = await import(
+          "./voice/index.js"
+        );
+        const adapterCreator = createPluginDiscordAdapter(gateway.voice);
+        const voiceClient = new WarRoomVoiceClient(ctx, {
+          guildId: voiceEnv.guildId!,
+          voiceChannelId: voiceEnv.voiceChannelId!,
+          textChannelWebhookUrl: voiceEnv.webhookUrl!,
+          deepgramApiKey: voiceEnv.deepgramApiKey!,
+          voiceAdapterCreator: adapterCreator,
+        });
+        await voiceClient.start();
+        voiceClientStop = () => voiceClient.stop();
+      } catch (error) {
+        ctx.logger.error("voice: startup failed (continuing without voice)", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    } else if (!voiceEnabled) {
+      ctx.logger.info(
+        "voice: disabled — missing one of WAR_ROOM_GUILD_ID, WAR_ROOM_VOICE_CHANNEL_ID, MICHAEL_VOICE_WEBHOOK_URL, DEEPGRAM_API_KEY",
+      );
+    }
+
     ctx.events.on("plugin.stopping", async () => {
+      if (voiceClientStop) {
+        try {
+          voiceClientStop();
+        } catch (error) {
+          ctx.logger.warn("voice: stop failed during plugin shutdown", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
       gateway.close();
     });
 

--- a/tests/voice-stt-deepgram.test.ts
+++ b/tests/voice-stt-deepgram.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { WebSocketServer, WebSocket } from "ws";
+import { DeepgramSTTAdapter } from "../src/voice/stt-deepgram.js";
+
+let mockServer: WebSocketServer | undefined;
+
+function makeServer(handler: (ws: WebSocket) => void): Promise<number> {
+  return new Promise((resolve) => {
+    mockServer = new WebSocketServer({ port: 0 }, () => {
+      const port = (mockServer!.address() as { port: number }).port;
+      resolve(port);
+    });
+    mockServer.on("connection", handler);
+  });
+}
+
+afterEach(() => {
+  mockServer?.close();
+  mockServer = undefined;
+});
+
+describe("DeepgramSTTAdapter", () => {
+  it("sends PCM then Finalize and resolves with final transcript", async () => {
+    let receivedBinary = false;
+    let receivedFinalize = false;
+    const port = await makeServer((ws) => {
+      ws.on("message", (data, isBinary) => {
+        if (isBinary) {
+          receivedBinary = true;
+        } else {
+          const msg = JSON.parse(data.toString());
+          if (msg.type === "Finalize") {
+            receivedFinalize = true;
+            ws.send(
+              JSON.stringify({
+                type: "Results",
+                is_final: true,
+                channel: { alternatives: [{ transcript: "hello world" }] },
+              }),
+            );
+          }
+        }
+      });
+    });
+
+    const adapter = new DeepgramSTTAdapter({
+      apiKey: "test-key",
+      baseUrl: `ws://localhost:${port}`,
+    });
+    const transcript = await adapter.transcribeUtterance(Buffer.from([1, 2, 3, 4]));
+
+    expect(receivedBinary).toBe(true);
+    expect(receivedFinalize).toBe(true);
+    expect(transcript).toBe("hello world");
+  });
+
+  it("rejects on WS close without a final result", async () => {
+    const port = await makeServer((ws) => {
+      ws.on("message", () => {
+        ws.close();
+      });
+    });
+
+    const adapter = new DeepgramSTTAdapter({
+      apiKey: "test-key",
+      baseUrl: `ws://localhost:${port}`,
+    });
+
+    await expect(
+      adapter.transcribeUtterance(Buffer.from([1, 2, 3, 4])),
+    ).rejects.toThrow(/no final transcript/i);
+  });
+
+  it("rejects on WS auth-failure close", async () => {
+    const port = await makeServer((ws) => {
+      // simulate Deepgram-style auth-failure close
+      ws.close(4001, "unauthorized");
+    });
+
+    const adapter = new DeepgramSTTAdapter({
+      apiKey: "bad-key",
+      baseUrl: `ws://localhost:${port}`,
+    });
+
+    await expect(
+      adapter.transcribeUtterance(Buffer.from([1, 2, 3, 4])),
+    ).rejects.toThrow();
+  });
+
+  it("returns empty string when transcript is empty (silence)", async () => {
+    const port = await makeServer((ws) => {
+      ws.on("message", (_data, isBinary) => {
+        if (!isBinary) {
+          ws.send(
+            JSON.stringify({
+              type: "Results",
+              is_final: true,
+              channel: { alternatives: [{ transcript: "" }] },
+            }),
+          );
+        }
+      });
+    });
+
+    const adapter = new DeepgramSTTAdapter({
+      apiKey: "test-key",
+      baseUrl: `ws://localhost:${port}`,
+    });
+    const transcript = await adapter.transcribeUtterance(Buffer.from([1, 2, 3, 4]));
+    expect(transcript).toBe("");
+  });
+});

--- a/tests/voice-text-channel-relay.test.ts
+++ b/tests/voice-text-channel-relay.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { WebhookTextChannelRelay } from "../src/voice/text-channel-relay.js";
+
+const FAKE_URL = "https://discord.example/api/webhooks/123/abc";
+
+describe("WebhookTextChannelRelay", () => {
+  beforeEach(() => {
+    vi.spyOn(global, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("POSTs to the webhook URL with content and Michael (voice) username", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
+
+    const relay = new WebhookTextChannelRelay({ webhookUrl: FAKE_URL });
+    await relay.postTranscript("hello alfred", { durationSec: 1.2 });
+
+    expect(global.fetch).toHaveBeenCalledOnce();
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    const [url, opts] = calls[0] as [string, RequestInit];
+    expect(url).toBe(FAKE_URL);
+    const body = JSON.parse(opts.body as string);
+    expect(body.content).toBe("hello alfred");
+    expect(body.username).toBe("Michael (voice)");
+  });
+
+  it("retries once on 5xx then succeeds", async () => {
+    const mock = global.fetch as ReturnType<typeof vi.fn>;
+    mock
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const relay = new WebhookTextChannelRelay({ webhookUrl: FAKE_URL });
+    await relay.postTranscript("retry test", { durationSec: 1.0 });
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry on 4xx auth failure", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response("invalid webhook token", { status: 401 }),
+    );
+
+    const relay = new WebhookTextChannelRelay({ webhookUrl: FAKE_URL });
+    await expect(
+      relay.postTranscript("auth fail", { durationSec: 0.5 }),
+    ).rejects.toThrow(/401/);
+
+    expect(global.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("skips empty transcripts (silence detected, no text)", async () => {
+    const relay = new WebhookTextChannelRelay({ webhookUrl: FAKE_URL });
+    await relay.postTranscript("", { durationSec: 0.3 });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("trims whitespace-only transcripts to empty (also skipped)", async () => {
+    const relay = new WebhookTextChannelRelay({ webhookUrl: FAKE_URL });
+    await relay.postTranscript("   \n  ", { durationSec: 0.5 });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses custom username if configured", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
+
+    const relay = new WebhookTextChannelRelay({
+      webhookUrl: FAKE_URL,
+      username: "Custom Name",
+    });
+    await relay.postTranscript("hi", { durationSec: 0.5 });
+
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    const [, opts] = calls[0] as [string, RequestInit];
+    const body = JSON.parse(opts.body as string);
+    expect(body.username).toBe("Custom Name");
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Phase 1** of MRTek's war-room voice initiative — adds an inbound-only voice client to `paperclip-plugin-discord`. The bot joins a configured Discord voice channel, transcribes user speech via Deepgram streaming STT, and posts each utterance to a configured text-channel webhook (in MRTek's case, the war-room channel as `Michael (voice)`). The existing text routing then handles the rest exactly as if the operator had typed.

This is the first phase of the design spec [`2026-05-28-war-room-voice-design.md`](https://github.com/Mission-Ready-Tech/mrt-ai-agent-platform/blob/docs/war-room-voice-design/docs/superpowers/specs/2026-05-28-war-room-voice-design.md) in the MRTek repo. No TTS yet (Phase 2); no per-agent voice lookup yet (Phase 2).

## How it fits the existing architecture

Originally I thought this would need plugin-SDK feature requests (the SDK uses JSON-RPC stdio between host and worker — no raw gateway access). Inspection showed this plugin already maintains its own Discord Gateway WebSocket in `src/gateway.ts`. So voice support is a plain extension of that existing module — no SDK changes required. See [`docs/superpowers/research/2026-05-28-plugin-sdk-voice-feasibility.md`](https://github.com/Mission-Ready-Tech/mrt-ai-agent-platform/blob/docs/war-room-voice-design/docs/superpowers/research/2026-05-28-plugin-sdk-voice-feasibility.md) for the full feasibility verdict.

## What changed

**Extended (1 file):**
- `src/gateway.ts` — adds optional `enableVoice: boolean` option; when true: adds `GUILD_VOICE_STATES` intent (128) and dispatches `VOICE_STATE_UPDATE` / `VOICE_SERVER_UPDATE` events to subscribed handlers. Returns a new `voice?` handle exposing `sendPayload`, `onVoiceStateUpdate`, `onVoiceServerUpdate`. **Fully backward-compatible** — default is `enableVoice: false`; existing callers see no change.

**Created (5 files, all under new `src/voice/`):**
- `types.ts` — shared types (`VoiceClientConfig`, `STTAdapter`, `TextChannelRelay`)
- `stt-deepgram.ts` — Deepgram streaming WebSocket adapter (one WS per utterance with `Finalize` on flush)
- `text-channel-relay.ts` — webhook POST as `Michael (voice)` with 5xx retry-once, 4xx hard-fail, empty-transcript skip
- `discord-adapter.ts` — bridges `gateway.voice` primitives to `@discordjs/voice`'s `DiscordGatewayAdapterCreator` contract
- `client.ts` — `WarRoomVoiceClient`: `joinVoiceChannel` + per-speaker subscribe with `EndBehaviorType.AfterSilence(800ms)` (built-in VAD — no separate library) + Opus→PCM via `prism-media` + STT + relay

**Tests (2 files, 10 cases):**
- `tests/voice-stt-deepgram.test.ts` (4 cases) — mock `WebSocketServer`; tests `Finalize` flag, close-without-final, auth failure, empty-transcript success
- `tests/voice-text-channel-relay.test.ts` (6 cases) — mock `fetch`; tests POST shape, 5xx retry, 4xx no-retry, empty/whitespace skip, custom username

**Worker (1 file):**
- `src/worker.ts` — startup hook: if all 4 voice env vars are set (`WAR_ROOM_GUILD_ID`, `WAR_ROOM_VOICE_CHANNEL_ID`, `MICHAEL_VOICE_WEBHOOK_URL`, `DEEPGRAM_API_KEY`), instantiate the voice client. Failures are caught and logged — they never crash the plugin or affect text routing. Stop hook registered alongside `gateway.close` on `plugin.stopping`.

**Deps added (4 + 2 @types):**
- `@discordjs/voice` ^0.18.0
- `prism-media` ^1.3.5 (Opus codec)
- `libsodium-wrappers` ^0.7.13 (voice packet encryption)
- `ws` ^8.18.0 (Deepgram client)

## Validation

- ✅ Typecheck (`npm run typecheck`) — clean
- ✅ Full test suite — **457 passed** (447 existing + 10 new voice)
- ✅ Build (`npm run build`) — clean; all `dist/voice/*.{js,d.ts}` produced

## Out of scope for this PR

- TTS outbound (Phase 2)
- Per-agent voice lookup via YAML frontmatter (Phase 2 — depends on MRTek-side [PR #33](https://github.com/Mission-Ready-Tech/mrt-ai-agent-platform/pull/33))
- Cost guard + fallback (Phase 3)
- Latency CI checks + golden fixtures (Phase 4)
- Operator-side dev smoke test (separate runbook)

## Known minor limitation

`createPluginDiscordAdapter` registers handlers on `gateway.voice` that can't be removed today (the handler lists in `gateway.ts` are append-only). For Phase 1 the bot joins one voice channel for the plugin's lifetime so this doesn't leak. If/when reconnect-or-rejoin semantics are added, a `removeHandler` primitive on the gateway will be needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
