### PR TITLE
fix: handle disabled secret resolution gracefully (port of telegram #66)

### DIFF
--- a/src/runtime-token.ts
+++ b/src/runtime-token.ts
@@ -1,0 +1,36 @@
+import type { PluginContext, PluginHealthDiagnostics } from "@paperclipai/plugin-sdk";
+
+export type DiscordRuntimeHealth = PluginHealthDiagnostics & {
+  message?: string;
+  details?: Record<string, unknown>;
+};
+
+export const SECRET_RESOLUTION_DISABLED_MESSAGE = "Plugin secret references are disabled until company-scoped plugin config lands";
+export const SECRET_RESOLUTION_ISSUE_URL = "https://github.com/mvanhorn/paperclip-plugin-discord/issues/61";
+
+export async function resolveStartupDiscordBotToken(
+  ctx: PluginContext,
+  tokenRef: string,
+  setHealth: (health: DiscordRuntimeHealth) => void,
+): Promise<string | undefined> {
+  try {
+    const token = await ctx.secrets.resolve(tokenRef);
+    setHealth({ status: "ok" });
+    return token;
+  } catch (err) {
+    const error = String(err);
+    setHealth({
+      status: "degraded",
+      message: SECRET_RESOLUTION_DISABLED_MESSAGE,
+      details: {
+        issue: "paperclip-plugin-secret-resolution-disabled",
+        reference: SECRET_RESOLUTION_ISSUE_URL,
+      },
+    });
+    ctx.logger.error("Discord plugin cannot resolve bot token secret; runtime features are disabled", {
+      error,
+      reference: SECRET_RESOLUTION_ISSUE_URL,
+    });
+    return undefined;
+  }
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -44,10 +44,12 @@ import { DiscordAdapter } from "./adapter.js";
 import { processMediaMessage, type MediaAttachment } from "./media-pipeline.js";
 import { registerCommand, parseCommandMessage, executeCommand, listCommands } from "./custom-commands.js";
 import { registerWatch, checkWatches } from "./proactive-suggestions.js";
+import { resolveStartupDiscordBotToken, type DiscordRuntimeHealth } from "./runtime-token.js";
 
 // Module-level state captured during setup() so onWebhook() can reuse it.
 let _pluginCtx: PluginContext | null = null;
 let _cmdCtx: CommandContext | null = null;
+let runtimeHealth: DiscordRuntimeHealth = { status: "ok" };
 
 import { resolveCompanyId } from "./company-resolver.js";
 import {
@@ -385,10 +387,23 @@ const plugin = definePlugin({
       );
     }
 
-    const token = await ctx.secrets.resolve(config.discordBotTokenRef);
-    const paperclipBoardApiKey = config.paperclipBoardApiKeyRef
-      ? await ctx.secrets.resolve(config.paperclipBoardApiKeyRef)
-      : "";
+    const token = await resolveStartupDiscordBotToken(ctx, config.discordBotTokenRef, (health) => {
+      runtimeHealth = health;
+    });
+    if (!token) {
+      ctx.logger.warn("Discord plugin runtime disabled because bot token could not be resolved");
+      return;
+    }
+    let paperclipBoardApiKey = "";
+    if (config.paperclipBoardApiKeyRef) {
+      try {
+        paperclipBoardApiKey = await ctx.secrets.resolve(config.paperclipBoardApiKeyRef);
+      } catch (err) {
+        ctx.logger.warn("Discord plugin could not resolve Paperclip board API key; board features are disabled", {
+          error: String(err),
+        });
+      }
+    }
     const baseUrl = config.paperclipBaseUrl || "http://localhost:3100";
     const retentionDays = config.intelligenceRetentionDays || 30;
     const defaultGuildId = normalizeDiscordId(config.defaultGuildId);
@@ -1605,7 +1620,7 @@ const plugin = definePlugin({
   },
 
   async onHealth(): Promise<PluginHealthDiagnostics> {
-    return { status: "ok" };
+    return runtimeHealth;
   },
 });
 

--- a/tests/runtime-token.test.ts
+++ b/tests/runtime-token.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import {
+  SECRET_RESOLUTION_DISABLED_MESSAGE,
+  SECRET_RESOLUTION_ISSUE_URL,
+  resolveStartupDiscordBotToken,
+  type DiscordRuntimeHealth,
+} from "../src/runtime-token.js";
+
+function makeContext(resolve: () => Promise<string>): PluginContext {
+  return {
+    secrets: { resolve },
+    logger: {
+      error: vi.fn(),
+    },
+  } as unknown as PluginContext;
+}
+
+describe("resolveStartupDiscordBotToken", () => {
+  it("returns the resolved bot token and marks health ok", async () => {
+    const health: DiscordRuntimeHealth[] = [];
+    const ctx = makeContext(async () => "bot-token");
+
+    const token = await resolveStartupDiscordBotToken(ctx, "secret-ref", (next) => health.push(next));
+
+    expect(token).toBe("bot-token");
+    expect(health).toEqual([{ status: "ok" }]);
+  });
+
+  it("degrades health and does not throw when Paperclip secret resolution fails", async () => {
+    const health: DiscordRuntimeHealth[] = [];
+    const ctx = makeContext(async () => {
+      throw new Error(SECRET_RESOLUTION_DISABLED_MESSAGE);
+    });
+
+    const token = await resolveStartupDiscordBotToken(ctx, "secret-ref", (next) => health.push(next));
+
+    expect(token).toBeUndefined();
+    expect(health).toEqual([{
+      status: "degraded",
+      message: SECRET_RESOLUTION_DISABLED_MESSAGE,
+      details: {
+        issue: "paperclip-plugin-secret-resolution-disabled",
+        reference: SECRET_RESOLUTION_ISSUE_URL,
+      },
+    }]);
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      "Discord plugin cannot resolve bot token secret; runtime features are disabled",
+      {
+        error: `Error: ${SECRET_RESOLUTION_DISABLED_MESSAGE}`,
+        reference: SECRET_RESOLUTION_ISSUE_URL,
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Problem

On Paperclip hosts v2026.512.0 and later, this plugin cannot activate at all — worker initialization dies with `Invalid secret reference` / `Plugin secret references are disabled...`. Tracked in #61.

## Root cause

The host's secret resolver fails closed since paperclipai/paperclip#5429 (`plugin-secrets-handler.ts` throws unconditionally, pending company-scoped plugin config — fix tracked upstream in paperclipai/paperclip#6148 / #6173). Our worker resolved `discordBotTokenRef` (and the optional `paperclipBoardApiKeyRef`) unguarded at activation, so the throw propagated and the plugin landed in `error` state.

## Fix

Direct port of the pattern merged in mvanhorn/paperclip-plugin-telegram#66:

- New `src/runtime-token.ts` — `resolveStartupDiscordBotToken()` catches the resolve failure, flips module health to `degraded` with a machine-readable `details.issue` and a pointer to #61, and logs the cause.
- `setup()` returns early instead of crashing when the token cannot be resolved; the optional board API key resolve is wrapped so its failure only disables board features.
- `onHealth()` now reports the runtime health instead of a hardcoded `ok`.

Behavior on healthy hosts is unchanged (`status: "ok"`, token resolved as before). On affected hosts the plugin activates inert and tells the operator why — it does not restore functionality; that requires the upstream fix.

## Verification

No CI on this repo — local gate: `npm ci && npm run typecheck && npm run test` → tsc clean, **476/476 tests passing (23 files)**, including 2 new tests pinning the ok and degraded paths of `resolveStartupDiscordBotToken`.

---
<sub><em>**[@superbiche](https://github.com/superbiche)** · co-maintainer · drafted with Claude Fable 5.</em></sub>

https://claude.ai/code/session_014EtUqWXNruHzvyfeoajMpR
